### PR TITLE
Refactor utility

### DIFF
--- a/common.h
+++ b/common.h
@@ -2071,13 +2071,7 @@ extern bool SupportIdn;
 static inline auto IdnToAscii(std::wstring const& unicode) {
 	if (!SupportIdn || empty(unicode))
 		return unicode;
-	auto length = IdnToAscii(0, data(unicode), size_as<int>(unicode), nullptr, 0);
-	if (length == 0)
-		return unicode;
-	std::wstring ascii(static_cast<size_t>(length), L'\0');
-	auto result = IdnToAscii(0, data(unicode), size_as<int>(unicode), data(ascii), length);
-	assert(result == length);
-	return ascii;
+	return convert<wchar_t>([](auto src, auto srclen, auto dst, auto dstlen) { return IdnToAscii(0, src, srclen, dst, dstlen); }, unicode);
 }
 static inline auto InputDialog(int dialogId, HWND parent, char *Title, char *Buf, int maxlength = 0, int* flag = nullptr, int helpTopicId = IDH_HELP_TOPIC_0000001) {
 	struct Data {

--- a/common.h
+++ b/common.h
@@ -1996,19 +1996,15 @@ static inline auto operator+(std::basic_string_view<Char, Traits> const& left, s
 	std::copy(begin(right), end(right), it);
 	return result;
 }
-std::wstring u8(std::string_view const& utf8);
-std::string u8(std::wstring_view const& wide);
-template<class Char>
-static inline auto u8(const Char* str) {
-	return u8(std::basic_string_view<Char>{ str });
+static inline auto u8(std::string_view utf8) {
+	return convert<wchar_t>([](auto src, auto srclen, auto dst, auto dstlen) { return MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, src, srclen, dst, dstlen); }, utf8);
+}
+static inline auto u8(std::wstring_view wide) {
+	return convert<char>([](auto src, auto srclen, auto dst, auto dstlen) { return WideCharToMultiByte(CP_UTF8, 0, src, srclen, dst, dstlen, nullptr, nullptr); }, wide);
 }
 template<class Char>
 static inline auto u8(const Char* str, size_t len) {
 	return u8(std::basic_string_view<Char>{ str, len });
-}
-template<class Char, class Traits, class Allocator>
-static inline auto u8(std::basic_string<Char, Traits, Allocator> const& str) {
-	return u8(std::basic_string_view<Char>{ data(str), size(str) });
 }
 static auto ieq(std::wstring const& left, std::wstring const& right) {
 	return std::equal(begin(left), end(left), begin(right), end(right), [](auto const l, auto const r) { return std::towupper(l) == std::towupper(r); });

--- a/common.h
+++ b/common.h
@@ -1966,6 +1966,22 @@ template<class Size, class Source>
 constexpr auto size_as(Source const& source) {
 	return static_cast<Size>(std::size(source));
 }
+template<class DstChar, class SrcChar, class Fn>
+static inline auto convert(Fn&& fn, std::basic_string_view<SrcChar> src) {
+	auto len1 = fn(data(src), size_as<int>(src), nullptr, 0);
+	std::basic_string<DstChar> dst(len1, 0);
+	auto len2 = fn(data(src), size_as<int>(src), data(dst), len1);
+	dst.resize(len2);
+	return dst;
+}
+template<class DstChar, class Fn>
+static inline auto convert(Fn&& fn, std::string_view src) {
+	return convert<DstChar, char>(std::forward<Fn>(fn), src);
+}
+template<class DstChar, class Fn>
+static inline auto convert(Fn&& fn, std::wstring_view src) {
+	return convert<DstChar, wchar_t>(std::forward<Fn>(fn), src);
+}
 template<class Char, class Traits, class Alloc>
 static inline auto operator+(std::basic_string<Char, Traits, Alloc> const& left, std::basic_string_view<Char, Traits> const& right) {
 	std::basic_string<Char, Traits, Alloc> result(size(left) + size(right), Char(0));

--- a/misc.cpp
+++ b/misc.cpp
@@ -1617,24 +1617,3 @@ HBITMAP ResizeBitmap(HBITMAP hBitmap, int UnitSizeX, int UnitSizeY, int ScaleNum
 	}
 	return hDstBitmap;
 }
-
-
-std::wstring u8(std::string_view const& utf8) {
-	auto length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, data(utf8), size_as<int>(utf8), nullptr, 0);
-	if (length == 0)
-		return {};
-	std::wstring buffer(length, L'\0');
-	auto result = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, data(utf8), size_as<int>(utf8), data(buffer), length);
-	assert(result == length);
-	return buffer;
-}
-
-std::string u8(std::wstring_view const& wide) {
-	auto length = WideCharToMultiByte(CP_UTF8, 0, data(wide), size_as<int>(wide), nullptr, 0, nullptr, nullptr);
-	if (length == 0)
-		return {};
-	std::string buffer(length, '\0');
-	auto result = WideCharToMultiByte(CP_UTF8, 0, data(wide), size_as<int>(wide), data(buffer), length, nullptr, nullptr);
-	assert(result == length);
-	return buffer;
-}


### PR DESCRIPTION
- [MultiByteToWideChar](https://docs.microsoft.com/en-us/windows/desktop/api/stringapiset/nf-stringapiset-multibytetowidechar)
- [WideCharToMultiByte](https://docs.microsoft.com/en-us/windows/desktop/api/stringapiset/nf-stringapiset-widechartomultibyte)
- [IdnToAscii](https://docs.microsoft.com/en-us/windows/desktop/api/winnls/nf-winnls-idntoascii)
- [NormalizeString](https://docs.microsoft.com/en-us/windows/desktop/api/winnls/nf-winnls-normalizestring)

は類似のインターフェースを持っている。１度目の呼び出しでバッファサイズを取得し、２度目に変換を行う。この処理を行う`convert`テンプレート関数を導入する。

なお、

- [ConvertINetMultiByteToUnicode](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/aa741105(v=vs.85))
- [ConvertINetUnicodeToMultiByte](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/aa741107(v=vs.85))

はバッファサイズを返さないため`convert`を使えない。