### PR TITLE
ログウィンドウの更新頻度を下げパフォーマンスを改善する

### DIFF
--- a/common.h
+++ b/common.h
@@ -37,6 +37,7 @@
 #include <charconv>
 #include <chrono>
 #include <filesystem>
+#include <fstream>
 #include <future>
 #include <iterator>
 #include <map>
@@ -1512,7 +1513,6 @@ void _SetTaskMsg(const char* format, ...);
 #else
 #define SetTaskMsg(...) _SetTaskMsg(__VA_ARGS__)
 #endif
-int SaveTaskMsg(char *Fname);
 void DispTaskMsg(void);
 void _DoPrintf(const char* format, ...);
 #ifdef _DEBUG

--- a/mbswrapper.cpp
+++ b/mbswrapper.cpp
@@ -1068,20 +1068,7 @@ START_ROUTINE
 		break;
 	default:
 		GetClassNameW(hWnd, ClassName, sizeof(ClassName) / sizeof(wchar_t));
-		if(_wcsicmp(ClassName, WC_EDITW) == 0)
-		{
-			switch(Msg)
-			{
-			case EM_REPLACESEL:
-				pw0 = DuplicateMtoW((LPCSTR)lParam, -1);
-				r = SendMessageW(hWnd, EM_REPLACESEL, wParam, (LPARAM)pw0);
-				break;
-			default:
-				r = SendMessageW(hWnd, Msg, wParam, lParam);
-				break;
-			}
-		}
-		else if(_wcsicmp(ClassName, WC_COMBOBOXW) == 0)
+		if(_wcsicmp(ClassName, WC_COMBOBOXW) == 0)
 		{
 			switch(Msg)
 			{


### PR DESCRIPTION
#97 を受け、書き込みはキューに溜め、ログウィンドウは100fpsタイマーのタイミングで更新するようにする。