### PR TITLE
Directoryまわりの改善

### DIFF
--- a/common.h
+++ b/common.h
@@ -1352,6 +1352,7 @@ typedef struct
 
 /*===== main.c =====*/
 
+fs::path systemDirectory();
 int PASCAL WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpszCmdLine, int cmdShow);
 void DispWindowTitle();
 HWND GetMainHwnd(void);

--- a/common.h
+++ b/common.h
@@ -1485,7 +1485,7 @@ void SetRemoteDirHist(char *Path);
 void SetLocalDirHist(char *Path);
 void AskLocalCurDir(char *Buf, int Max);
 void AskRemoteCurDir(char *Buf, int Max);
-void SetCurrentDirAsDirHist(void);
+void SetCurrentDirAsDirHist();
 void DispDotFileMode(void);
 void LocalRbuttonMenu(int Pos);
 void RemoteRbuttonMenu(int Pos);
@@ -1655,7 +1655,7 @@ void ReconnectProc(void);
 
 /*===== local.c =====*/
 
-int DoLocalCWD(char *Path);
+int DoLocalCWD(const char *Path);
 void DoLocalMKD(char *Path);
 void DoLocalPWD(char *Buf);
 void DoLocalRMD(char *Path);

--- a/filelist.cpp
+++ b/filelist.cpp
@@ -2365,7 +2365,6 @@ void MakeDroppedFileList(WPARAM wParam, char *Cur, FILELIST **Base)
 	int Max;
 	int i;
 	char Name[FMAX_PATH+1];
-	char Tmp[FMAX_PATH+1];
 	FILELIST Pkt;
 	HANDLE fHnd;
 	WIN32_FIND_DATA Find;
@@ -2418,8 +2417,8 @@ void MakeDroppedFileList(WPARAM wParam, char *Cur, FILELIST **Base)
 		}
 	}
 
-	GetCurrentDirectory(FMAX_PATH, Tmp);
-	SetCurrentDirectory(Cur);
+	auto const saved = fs::current_path();
+	fs::current_path(fs::u8path(Cur));
 	for(i = 0; i < Max; i++)
 	{
 		DragQueryFile((HDROP)wParam, i, Name, FMAX_PATH);
@@ -2436,7 +2435,7 @@ void MakeDroppedFileList(WPARAM wParam, char *Cur, FILELIST **Base)
 			MakeLocalTree(Pkt.File, Base);
 		}
 	}
-	SetCurrentDirectory(Tmp);
+	fs::current_path(saved);
 
 	DragFinish((HDROP)wParam);
 

--- a/local.cpp
+++ b/local.cpp
@@ -30,28 +30,15 @@
 #include "common.h"
 
 
-/*----- ローカル側のディレクトリ変更 -------------------------------------------
-*
-*	Parameter
-*		char *Path : パス名
-*
-*	Return Value
-*		int ステータス
-*			FFFTP_SUCCESS/FFFTP_FAIL
-*----------------------------------------------------------------------------*/
-
-int DoLocalCWD(char *Path)
-{
-	int Sts;
-
-	Sts = FFFTP_SUCCESS;
+// ローカル側のディレクトリ変更
+int DoLocalCWD(const char *Path) {
 	SetTaskMsg(">>CD %s", Path);
-	if(SetCurrentDirectory(Path) != TRUE)
-	{
-		SetTaskMsg(MSGJPN145);
-		Sts = FFFTP_FAIL;
-	}
-	return(Sts);
+	std::error_code ec;
+	fs::current_path(fs::u8path(Path), ec);
+	if (!ec)
+		return FFFTP_SUCCESS;
+	SetTaskMsg(MSGJPN145);
+	return FFFTP_FAIL;
 }
 
 
@@ -73,20 +60,9 @@ void DoLocalMKD(char *Path)
 }
 
 
-/*----- ローカル側のカレントディレクトリ取得 -----------------------------------
-*
-*	Parameter
-*		char *Buf : パス名を返すバッファ
-*
-*	Return Value
-*		なし
-*----------------------------------------------------------------------------*/
-
-void DoLocalPWD(char *Buf)
-{
-	if(GetCurrentDirectory(FMAX_PATH, Buf) == 0)
-		strcpy(Buf, "");
-	return;
+// ローカル側のカレントディレクトリ取得
+void DoLocalPWD(char *Buf) {
+	strcpy(Buf, fs::current_path().u8string().c_str());
 }
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -570,7 +570,7 @@ static int InitApp(LPSTR lpszCmdLine, int cmdShow)
 				hWndCurFocus = GetLocalHwnd();
 
 				if(strlen(DefaultLocalPath) > 0)
-					SetCurrentDirectory(DefaultLocalPath);
+					fs::current_path(fs::u8path(DefaultLocalPath));
 
 				SetSortTypeImm(LocalFileSort, LocalDirSort, RemoteFileSort, RemoteDirSort);
 				SetTransferTypeImm(TransMode);

--- a/main.cpp
+++ b/main.cpp
@@ -253,7 +253,15 @@ int FwallNoSaveUser = NO;
 int MarkAsInternet = YES; 
 
 
-
+fs::path systemDirectory() {
+	static auto path = [] {
+		wchar_t directory[FMAX_PATH];
+		auto length = GetSystemDirectoryW(directory, size_as<UINT>(directory));
+		assert(0 < length);
+		return fs::path{ directory, directory + length };
+	}();
+	return path;
+}
 
 
 /*----- メインルーチン --------------------------------------------------------

--- a/mbswrapper.cpp
+++ b/mbswrapper.cpp
@@ -1462,33 +1462,6 @@ END_ROUTINE
 	return r;
 }
 
-DWORD GetCurrentDirectoryM(DWORD nBufferLength, LPSTR lpBuffer)
-{
-	DWORD r = 0;
-	wchar_t* pw0 = NULL;
-START_ROUTINE
-	// TODO: バッファが不十分な場合に必要なサイズを返す
-	pw0 = AllocateStringW(nBufferLength * 4);
-	GetCurrentDirectoryW(nBufferLength * 4, pw0);
-	WtoM(lpBuffer, nBufferLength, pw0, -1);
-	r = TerminateStringM(lpBuffer, nBufferLength);
-END_ROUTINE
-	FreeDuplicatedString(pw0);
-	return r;
-}
-
-BOOL SetCurrentDirectoryM(LPCSTR lpPathName)
-{
-	BOOL r = FALSE;
-	wchar_t* pw0 = NULL;
-START_ROUTINE
-	pw0 = DuplicateMtoW(lpPathName, -1);
-	r = SetCurrentDirectoryW(pw0);
-END_ROUTINE
-	FreeDuplicatedString(pw0);
-	return r;
-}
-
 DWORD GetTempPathM(DWORD nBufferLength, LPSTR lpBuffer)
 {
 	DWORD r = 0;

--- a/mbswrapper.h
+++ b/mbswrapper.h
@@ -77,12 +77,6 @@ UINT DragQueryFileM(HDROP hDrop, UINT iFile, LPSTR lpszFile, UINT cch);
 #undef GetCommandLine
 #define GetCommandLine GetCommandLineM
 LPSTR GetCommandLineM();
-#undef GetCurrentDirectory
-#define GetCurrentDirectory GetCurrentDirectoryM
-DWORD GetCurrentDirectoryM(DWORD nBufferLength, LPSTR lpBuffer);
-#undef SetCurrentDirectory
-#define SetCurrentDirectory SetCurrentDirectoryM
-BOOL SetCurrentDirectoryM(LPCSTR lpPathName);
 #undef GetTempPath
 #define GetTempPath GetTempPathM
 DWORD GetTempPathM(DWORD nBufferLength, LPSTR lpBuffer);

--- a/registry.cpp
+++ b/registry.cpp
@@ -1547,14 +1547,12 @@ void ClearIni() {
 void SaveSettingsToFile() {
 	if (RegType == REGTYPE_REG) {
 		if (auto const path = SelectFile(false, GetMainHwnd(), IDS_SAVE_SETTING, L"FFFTP.reg", L"reg", { FileType::Reg, FileType::All }); !std::empty(path)) {
-			if (wchar_t systemDirectory[FMAX_PATH + 1]; GetSystemDirectoryW(systemDirectory, size_as<UINT>(systemDirectory)) > 0) {
-				wchar_t commandLine[FMAX_PATH * 2];
-				_snwprintf(commandLine, std::size(commandLine), LR"("%s\reg.exe" EXPORT HKCU\Software\sota\FFFTP "%s")", systemDirectory, path.c_str());
-				fs::remove(path);
-				STARTUPINFOW si{ sizeof(STARTUPINFOW) };
-				if (ProcessInformation pi; !CreateProcessW(nullptr, commandLine, nullptr, nullptr, false, CREATE_NO_WINDOW, nullptr, systemDirectory, &si, &pi))
-					MessageBox(GetMainHwnd(), MSGJPN285, "FFFTP", MB_OK | MB_ICONERROR);
-			}
+			wchar_t commandLine[FMAX_PATH * 2];
+			_snwprintf(commandLine, std::size(commandLine), LR"("%s\reg.exe" EXPORT HKCU\Software\sota\FFFTP "%s")", systemDirectory().c_str(), path.c_str());
+			fs::remove(path);
+			STARTUPINFOW si{ sizeof(STARTUPINFOW) };
+			if (ProcessInformation pi; !CreateProcessW(nullptr, commandLine, nullptr, nullptr, false, CREATE_NO_WINDOW, nullptr, systemDirectory().c_str(), &si, &pi))
+				MessageBox(GetMainHwnd(), MSGJPN285, "FFFTP", MB_OK | MB_ICONERROR);
 		}
 	} else {
 		if (auto const path = SelectFile(false, GetMainHwnd(), IDS_SAVE_SETTING, L"FFFTP-Backup.ini", L"ini", { FileType::Ini, FileType::All }); !std::empty(path))
@@ -1567,14 +1565,12 @@ void SaveSettingsToFile() {
 int LoadSettingsFromFile() {
 	if (auto const path = SelectFile(true, GetMainHwnd(), IDS_LOAD_SETTING, L"", L"", { FileType::Reg, FileType::Ini, FileType::All }); !std::empty(path)) {
 		if (ieq(path.extension(), L".reg"s)) {
-			if (wchar_t systemDirectory[FMAX_PATH + 1]; GetSystemDirectoryW(systemDirectory, size_as<UINT>(systemDirectory)) > 0) {
-				wchar_t commandLine[FMAX_PATH * 2];
-				_snwprintf(commandLine, std::size(commandLine), LR"("%s\reg.exe" IMPORT "%s")", systemDirectory, path.c_str());
-				STARTUPINFOW si{ sizeof(STARTUPINFOW), nullptr, nullptr, nullptr, 0, 0, 0, 0, 0, 0, 0, STARTF_USESHOWWINDOW, SW_HIDE };
-				if (ProcessInformation pi; CreateProcessW(nullptr, commandLine, nullptr, nullptr, false, CREATE_NO_WINDOW, nullptr, systemDirectory, &si, &pi))
-					return YES;
-				MessageBox(GetMainHwnd(), MSGJPN285, "FFFTP", MB_OK | MB_ICONERROR);
-			}
+			wchar_t commandLine[FMAX_PATH * 2];
+			_snwprintf(commandLine, std::size(commandLine), LR"("%s\reg.exe" IMPORT "%s")", systemDirectory().c_str(), path.c_str());
+			STARTUPINFOW si{ sizeof(STARTUPINFOW), nullptr, nullptr, nullptr, 0, 0, 0, 0, 0, 0, 0, STARTF_USESHOWWINDOW, SW_HIDE };
+			if (ProcessInformation pi; CreateProcessW(nullptr, commandLine, nullptr, nullptr, false, CREATE_NO_WINDOW, nullptr, systemDirectory().c_str(), &si, &pi))
+				return YES;
+			MessageBox(GetMainHwnd(), MSGJPN285, "FFFTP", MB_OK | MB_ICONERROR);
 		} else if (ieq(path.extension(), L".ini"s)) {
 			CopyFileW(path.c_str(), u8(AskIniFilePath()).c_str(), FALSE);
 			return YES;

--- a/tool.cpp
+++ b/tool.cpp
@@ -79,29 +79,8 @@ void OtpCalcTool() {
 }
 
 
-// FTPS対応
-void TurnStatefulFTPFilter()
-{
-	int ID;
-	char CurDir[FMAX_PATH+1];
-	char SysDir[FMAX_PATH+1];
-	ID = MessageBox(GetMainHwnd(), MSGJPN341, "FFFTP", MB_YESNOCANCEL);
-	if(ID == IDYES || ID == IDNO)
-	{
-		if(GetCurrentDirectory(FMAX_PATH, CurDir) > 0)
-		{
-			if(GetSystemDirectory(SysDir, FMAX_PATH) > 0)
-			{
-				if(SetCurrentDirectory(SysDir))
-				{
-					if(ShellExecute(NULL, "runas", "netsh", ID == IDYES ? "advfirewall set global statefulftp enable" : "advfirewall set global statefulftp disable", NULL, SW_SHOW) <= (HINSTANCE)32)
-					{
-						MessageBox(GetMainHwnd(), MSGJPN342, "FFFTP", MB_OK | MB_ICONERROR);
-					}
-					SetCurrentDirectory(CurDir);
-				}
-			}
-		}
-	}
+void TurnStatefulFTPFilter() {
+	if (auto ID = MessageBox(GetMainHwnd(), MSGJPN341, "FFFTP", MB_YESNOCANCEL); ID == IDYES || ID == IDNO)
+		if (PtrToInt(ShellExecuteW(NULL, L"runas", L"netsh", ID == IDYES ? L"advfirewall set global statefulftp enable" : L"advfirewall set global statefulftp disable", systemDirectory().c_str(), SW_SHOW)) <= 32)
+			MessageBox(GetMainHwnd(), MSGJPN342, "FFFTP", MB_OK | MB_ICONERROR);
 }
-

--- a/toolmenu.cpp
+++ b/toolmenu.cpp
@@ -1768,19 +1768,9 @@ void AskRemoteCurDir(char *Buf, int Max)
 }
 
 
-/*----- カレントディレクトリを設定する ----------------------------------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		なし
-*----------------------------------------------------------------------------*/
-
-void SetCurrentDirAsDirHist(void)
-{
-	SetCurrentDirectory(LocalCurDir);
-	return;
+// カレントディレクトリを設定する
+void SetCurrentDirAsDirHist() {
+	fs::current_path(fs::u8path(LocalCurDir));
 }
 
 


### PR DESCRIPTION
- システムディレクトリの取得を１箇所にまとめる
- 子プロセスを起動する際、カレントディレクトリを移動するのではなく、引数で設定する
- カレントディレクトリの移動は`std::filesystem`を使用する