### PR TITLE
読み取り専用属性を外せない

### DIFF
--- a/getput.cpp
+++ b/getput.cpp
@@ -1719,7 +1719,7 @@ static int DownloadFile(TRANSPACKET *Pkt, SOCKET dSkt, int CreateMode, int *Canc
 		// 読み取り専用
 		if (MessageBox(GetMainHwnd(), MSGJPN296, MSGJPN086, MB_YESNO) == IDYES) {
 			// 属性を解除
-			SetFileAttributes(Pkt->LocalFile, dwFileAttributes ^ FILE_ATTRIBUTE_READONLY);
+			SetFileAttributesW(fs::u8path(Pkt->LocalFile).c_str(), dwFileAttributes & ~FILE_ATTRIBUTE_READONLY);
 		}
 	}
 


### PR DESCRIPTION
`SetFileAttributesA`が使用されているため、日本語を含むファイル名の場合に読み取り専用属性を外すことに失敗する。`SetFileAttributesM`は作らず直接`SetFileAttributesW`に置き換える。