### PR TITLE
ディレクトリ移動に失敗する

### DIFF
--- a/filelist.cpp
+++ b/filelist.cpp
@@ -2175,7 +2175,8 @@ void MakeDroppedFileList(WPARAM wParam, char *Cur, std::vector<FILELIST>& Base) 
 	}
 
 	auto const saved = fs::current_path();
-	fs::current_path(fs::u8path(Cur));
+	std::error_code ec;
+	fs::current_path(fs::u8path(Cur), ec);
 	for(i = 0; i < Max; i++)
 	{
 		DragQueryFile((HDROP)wParam, i, Name, FMAX_PATH);

--- a/main.cpp
+++ b/main.cpp
@@ -565,8 +565,8 @@ static int InitApp(LPSTR lpszCmdLine, int cmdShow)
 			{
 				hWndCurFocus = GetLocalHwnd();
 
-				if(strlen(DefaultLocalPath) > 0)
-					fs::current_path(fs::u8path(DefaultLocalPath));
+				if (std::error_code ec; strlen(DefaultLocalPath) > 0)
+					fs::current_path(fs::u8path(DefaultLocalPath), ec);
 
 				SetSortTypeImm(LocalFileSort, LocalDirSort, RemoteFileSort, RemoteDirSort);
 				SetTransferTypeImm(TransMode);

--- a/toolmenu.cpp
+++ b/toolmenu.cpp
@@ -1679,7 +1679,8 @@ void AskRemoteCurDir(char *Buf, int Max)
 
 // カレントディレクトリを設定する
 void SetCurrentDirAsDirHist() {
-	fs::current_path(fs::u8path(LocalCurDir));
+	std::error_code ec;
+	fs::current_path(fs::u8path(LocalCurDir), ec);
 }
 
 


### PR DESCRIPTION
ディレクトリ移動に失敗した際、例外処理していないのでそのまま停止してしまう。エラーを無視するように変更する。