### PR TITLE
FILELIST初期化に失敗する問題を修正

### DIFF
--- a/common.h
+++ b/common.h
@@ -1273,17 +1273,22 @@ typedef struct transpacket {
 /*===== ファイルリスト =====*/
 
 typedef struct filelist {
-	char File[FMAX_PATH+1];			/* ファイル名 */
-	char Node;						/* 種類 (NODE_xxx) */
-	char Link;						/* リンクファイルかどうか (YES/NO) */
-	LONGLONG Size;					/* ファイルサイズ */
-	int Attr;						/* 属性 */
-	FILETIME Time;					/* 時間(UTC) */
-	char Owner[OWNER_NAME_LEN+1];	/* オーナ名 */
-	char InfoExist;					/* ファイル一覧に存在した情報のフラグ (FINFO_xxx) */
-	// ファイルアイコン表示対応
-	int ImageId;					/* アイコン画像番号 */
+	char File[FMAX_PATH + 1] = {};			/* ファイル名 */
+	char Node = 0;							/* 種類 (NODE_xxx) */
+	char Link = 0;							/* リンクファイルかどうか (YES/NO) */
+	LONGLONG Size = 0;						/* ファイルサイズ */
+	int Attr = 0;							/* 属性 */
+	FILETIME Time = {};						/* 時間(UTC) */
+	char Owner[OWNER_NAME_LEN + 1] = {};	/* オーナ名 */
+	char InfoExist = 0;						/* ファイル一覧に存在した情報のフラグ (FINFO_xxx) */
+	int ImageId = 0;						/* アイコン画像番号 */
 	filelist() = default;
+	filelist(const char* file, char node) : Node{ node } {
+		strcpy(File, file);
+	}
+	filelist(const char* file, char node, char link, LONGLONG size, int attr, FILETIME time, char infoExist) : Node{ node }, Link{ link }, Size{ size }, Attr{ attr }, Time{ time }, InfoExist{ infoExist } {
+		strcpy(File, file);
+	}
 	filelist(const char* file, char node, char link, LONGLONG size, int attr, FILETIME time, const char* owner, char infoExist) : Node{ node }, Link{ link }, Size{ size }, Attr{ attr }, Time{ time }, InfoExist{ infoExist } {
 		strcpy(File, file);
 		strcpy(Owner, owner);

--- a/filelist.cpp
+++ b/filelist.cpp
@@ -1088,14 +1088,14 @@ void GetLocalDirForWnd(void)
 		if (DotFile != YES && data.cFileName[0] == L'.')
 			return;
 		if (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-			files.emplace_back(u8(data.cFileName).c_str(), NODE_DIR, NO, MakeLongLong(data.nFileSizeHigh, data.nFileSizeLow), 0, data.ftLastWriteTime, "", FINFO_ALL);
+			files.emplace_back(u8(data.cFileName).c_str(), NODE_DIR, NO, MakeLongLong(data.nFileSizeHigh, data.nFileSizeLow), 0, data.ftLastWriteTime, FINFO_ALL);
 		else if (AskFilterStr(u8(data.cFileName).c_str(), NODE_FILE) == YES)
-			files.emplace_back(u8(data.cFileName).c_str(), NODE_FILE, NO, MakeLongLong(data.nFileSizeHigh, data.nFileSizeLow), 0, data.ftLastWriteTime, "", FINFO_ALL);
+			files.emplace_back(u8(data.cFileName).c_str(), NODE_FILE, NO, MakeLongLong(data.nFileSizeHigh, data.nFileSizeLow), 0, data.ftLastWriteTime, FINFO_ALL);
 	});
 
 	/* ドライブ */
 	if (DispDrives)
-		GetDrives([&files](const wchar_t drive[]) { files.emplace_back(u8(drive).c_str(), NODE_DRIVE, NO, 0, 0, FILETIME{}, "", FINFO_ALL); });
+		GetDrives([&files](const wchar_t drive[]) { files.emplace_back(u8(drive).c_str(), NODE_DRIVE, NO, 0, 0, FILETIME{}, FINFO_ALL); });
 
 	// ファイルアイコン表示対応
 	RefreshIconImageList(files);
@@ -2361,7 +2361,7 @@ void AddRemoteTreeToFileList(int Num, char *Path, int IncDir, std::vector<FILELI
 			std::visit([&Path, IncDir, &Base, &Dir](auto&& arg) {
 				if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, FILELIST>) {
 					if (AskFilterStr(arg.File, arg.Node) == YES && (arg.Node == NODE_FILE || IncDir == RDIR_CWD && arg.Node == NODE_DIR)) {
-						FILELIST Pkt{ Dir, arg.Node, arg.Link, arg.Size, arg.Attr, arg.Time, nullptr, arg.InfoExist };
+						FILELIST Pkt{ Dir, arg.Node, arg.Link, arg.Size, arg.Attr, arg.Time, arg.InfoExist };
 						if (0 < strlen(Pkt.File))
 							SetSlashTail(Pkt.File);
 						strcat(Pkt.File, arg.File);
@@ -2369,10 +2369,8 @@ void AddRemoteTreeToFileList(int Num, char *Path, int IncDir, std::vector<FILELI
 					}
 				} else {
 					static_assert(std::is_same_v<std::decay_t<decltype(arg)>, std::string>);
-					if (MakeDirPath(data(arg), LIST_UNKNOWN, Path, Dir) == FFFTP_SUCCESS && IncDir == RDIR_NLST) {
-						FILELIST Pkt{ Dir, NODE_DIR, 0, 0, 0, {}, nullptr, 0 };
-						AddFileList(Pkt, Base);
-					}
+					if (MakeDirPath(data(arg), LIST_UNKNOWN, Path, Dir) == FFFTP_SUCCESS && IncDir == RDIR_NLST)
+						AddFileList({ Dir, NODE_DIR }, Base);
 				}
 			}, line);
 }


### PR DESCRIPTION
FILELIST初期化に不正な値を渡していた。このため #117 が発生していた。
対処方法としてはコンストラクターを見直す。