### PR TITLE
空ディレクトリが存在するとファイル一覧が作成できない

### DIFF
--- a/common.h
+++ b/common.h
@@ -2115,18 +2115,21 @@ struct ProcessInformation : PROCESS_INFORMATION {
 	}
 };
 template<class Fn>
-static inline void FindFile(fs::path const& fileName, Fn&& fn) {
+static inline bool FindFile(fs::path const& fileName, Fn&& fn) {
+	auto result = false;
 	WIN32_FIND_DATAW data;
 	if (auto handle = FindFirstFileW(fileName.c_str(), &data); handle != INVALID_HANDLE_VALUE) {
+		result = true;
 		do {
 			if (DispIgnoreHide == YES && (data.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN))
 				continue;
 			if (std::wstring_view filename{ data.cFileName }; filename == L"."sv || filename == L".."sv)
 				continue;
-			fn(data);
-		} while (FindNextFileW(handle, &data));
+			result = fn(data);
+		} while (result && FindNextFileW(handle, &data));
 		FindClose(handle);
 	}
+	return result;
 }
 template<class Fn>
 static inline void GetDrives(Fn&& fn) {


### PR DESCRIPTION
#123 を修正する。
従来、`MakeLocalTree`ではファイルが存在しない場合、ディレクトリオープンに失敗とみなしてエラーと扱っていた。この判定は`.`および`..`の存在を前提としていた。
1d9ca913081e68deb4c140ab993a61ac9e4d3f92 で`FindFirstFileAttr`を`FindFile`にリファクタリングする際、`.`および`..`の除外処理を含めた。これにより呼び出し元はいちいち除外処理せずに済むようになった。
しかしこの変更により、`MakeLocalTree`は空ディレクトリをディレクトリオープンに失敗と誤判定するようになってしまった。