### PR TITLE
fix #146, add precondition.

### DIFF
--- a/filelist.cpp
+++ b/filelist.cpp
@@ -1516,7 +1516,7 @@ int GetNodeTime(int Win, int Pos, FILETIME* Buf) {
 int GetNodeSize(int Win, int Pos, LONGLONG* Buf) {
 	if (auto size = GetItemText(Win, Pos, 2); !empty(size)) {
 		size.erase(std::remove(begin(size), end(size), L','), end(size));
-		*Buf = stoll(size);
+		*Buf = !empty(size) && std::iswdigit(size[0]) ? stoll(size) : 0;
 		return YES;
 	} else {
 		*Buf = -1;
@@ -1547,7 +1547,7 @@ int GetNodeAttr(int Win, int Pos, int* Buf) {
 		if (auto attr = GetItemText(WIN_REMOTE, Pos, subitem); !empty(attr)) {
 			*Buf =
 #if defined(HAVE_TANDEM)
-				AskHostType() == HTYPE_TANDEM ? stoi(attr) :
+				AskHostType() == HTYPE_TANDEM ? (std::iswdigit(attr[0]) ? stoi(attr) : 0) :
 #endif
 				AttrString2Value(u8(attr).c_str());
 			return YES;

--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -913,7 +913,7 @@ void UploadListProc(int ChName, int All)
 			switch (id) {
 			case IDOK:
 				strncpy_s(TmpString, FMAX_PATH, u8(GetText(hDlg, UPDOWNAS_NEW)).c_str(), _TRUNCATE);
-				filecode = std::stoi(GetText(hDlg, UPDOWNAS_FILECODE));
+				filecode = GetDecimalText(hDlg, UPDOWNAS_FILECODE);
 				EndDialog(hDlg, true);
 				break;
 			case UPDOWNAS_STOP:
@@ -2473,7 +2473,7 @@ std::optional<std::wstring> ChmodDialog(std::wstring const& attr) {
 		INT_PTR OnInit(HWND hDlg) {
 			SendDlgItemMessageW(hDlg, PERM_NOW, EM_LIMITTEXT, 4, 0);
 			SetText(hDlg, PERM_NOW, attr);
-			SetAttrToDialog(hDlg, std::stoi(attr, nullptr, 16));
+			SetAttrToDialog(hDlg, !empty(attr) && std::iswdigit(attr[0]) ? stoi(attr, nullptr, 16) : 0);
 			return TRUE;
 		}
 		void OnCommand(HWND hDlg, WORD id) {

--- a/hostman.cpp
+++ b/hostman.cpp
@@ -1500,7 +1500,7 @@ struct Advanced {
 			TmpHost.Pasv = (int)SendDlgItemMessageW(hDlg, HSET_PASV, BM_GETCHECK, 0, 0);
 			TmpHost.FireWall = (int)SendDlgItemMessageW(hDlg, HSET_FIREWALL, BM_GETCHECK, 0, 0);
 			TmpHost.SyncMove = (int)SendDlgItemMessageW(hDlg, HSET_SYNCMOVE, BM_GETCHECK, 0, 0);
-			TmpHost.Port = stoi(GetText(hDlg, HSET_PORT));
+			TmpHost.Port = GetDecimalText(hDlg, HSET_PORT);
 			strncpy_s(TmpHost.Account, ACCOUNT_LEN + 1, u8(GetText(hDlg, HSET_ACCOUNT)).c_str(), _TRUNCATE);
 			TmpHost.TimeZone = (int)SendDlgItemMessageW(hDlg, HSET_TIMEZONE, CB_GETCURSEL, 0, 0) - 12;
 			TmpHost.Security = (int)SendDlgItemMessageW(hDlg, HSET_SECURITY, CB_GETCURSEL, 0, 0);

--- a/option.cpp
+++ b/option.cpp
@@ -256,7 +256,7 @@ struct Transfer2 {
 		case PSN_APPLY: {
 			strncpy_s(DefaultLocalPath, FMAX_PATH + 1, u8(GetText(hDlg, TRMODE2_LOCAL)).c_str(), _TRUNCATE);
 			FnameCnv = CnvButton::Get(hDlg);
-			TimeOut = stoi(GetText(hDlg, TRMODE2_TIMEOUT));
+			TimeOut = GetDecimalText(hDlg, TRMODE2_TIMEOUT);
 			CheckRange2(&TimeOut, 300, 0);
 			return PSNRET_NOERROR;
 		}
@@ -318,7 +318,7 @@ struct Transfer3 {
 		switch (nmh->code) {
 		case PSN_APPLY: {
 			GetFnameAttrFromListView(hDlg, DefAttrList);
-			FolderAttrNum = stoi(GetText(hDlg, TRMODE3_FOLDER_ATTR));
+			FolderAttrNum = GetDecimalText(hDlg, TRMODE3_FOLDER_ATTR);
 			FolderAttr = (int)SendDlgItemMessageW(hDlg, TRMODE3_FOLDER, BM_GETCHECK, 0, 0);
 			return PSNRET_NOERROR;
 		}
@@ -637,7 +637,7 @@ struct Firewall {
 			strncpy_s(FwallHost, HOST_ADRS_LEN + 1, u8(GetText(hDlg, FIRE_HOST)).c_str(), _TRUNCATE);
 			strncpy_s(FwallUser, USER_NAME_LEN + 1, u8(GetText(hDlg, FIRE_USER)).c_str(), _TRUNCATE);
 			strncpy_s(FwallPass, PASSWORD_LEN, u8(GetText(hDlg, FIRE_PASS)).c_str(), _TRUNCATE);
-			FwallPort = stoi(GetText(hDlg, FIRE_PORT));
+			FwallPort = GetDecimalText(hDlg, FIRE_PORT);
 			FwallDelimiter = u8(GetText(hDlg, FIRE_DELIMIT))[0];
 			FwallDefault = (int)SendDlgItemMessageW(hDlg, FIRE_USEIT, BM_GETCHECK, 0, 0);
 			PasvDefault = (int)SendDlgItemMessageW(hDlg, FIRE_PASV, BM_GETCHECK, 0, 0);
@@ -927,21 +927,10 @@ int SortSetting() {
 }
 
 
-/*----- ダイアログのコントロールから１０進数を取得 ----------------------------
-*
-*	Parameter
-*		HWND hDlg : ウインドウハンドル
-*		int Ctrl : コントロールのID
-*
-*	Return Value
-*		なし
-*----------------------------------------------------------------------------*/
-
-// hostman.cで使用
-//static int GetDecimalText(HWND hDlg, int Ctrl)
-int GetDecimalText(HWND hDlg, int Ctrl)
-{
-	return stoi(GetText(hDlg, Ctrl));
+// ダイアログのコントロールから１０進数を取得
+int GetDecimalText(HWND hDlg, int Ctrl) {
+	auto const text = GetText(hDlg, Ctrl);
+	return !empty(text) && std::iswdigit(text[0]) ? stoi(text) : 0;
 }
 
 


### PR DESCRIPTION
`std::stoi`呼び出しの前に事前テストを行う。