### PR TITLE
ファイル転送ダイアログの表示改善

### DIFF
--- a/Resource/ffftp.en-US.rc
+++ b/Resource/ffftp.en-US.rc
@@ -2475,8 +2475,6 @@ BEGIN
     IDS_MSGJPN114           "Upload cancelled."
     IDS_MSGJPN115           "Upload successful. (%d Sec. %d B/S)."
     IDS_MSGJPN116           "Upload successfil."
-    IDS_MSGJPN117           "Finished"
-    IDS_MSGJPN118           "Cancelled"
     IDS_MSGJPN119           "BINARY"
     IDS_MSGJPN120           "ASCII"
     IDS_MSGJPN121           "NONE"
@@ -2715,6 +2713,8 @@ BEGIN
     IDS_NEED_EXSITING_WINSCP_INI 
                             "The all settings will be lost after loading an INI file newly created with this feature into WinSCP.\nPlease choose an existing WinSCP.ini if you already use WinSCP and want to migrate hosts settings only."
     IDS_INVALID_PATH        "%s is invalid path.\r\nFFFTP doesn't download this file."
+    IDS_FINISHED            "Finished"
+    IDS_CANCELLED           "Cancelled"
 END
 
 #endif    // English (United States) resources

--- a/Resource/ffftp.ja-JP.rc
+++ b/Resource/ffftp.ja-JP.rc
@@ -2437,8 +2437,6 @@ BEGIN
     IDS_MSGJPN114           "アップロードを中止しました."
     IDS_MSGJPN115           "アップロードは正常終了しました. (%d Sec. %d B/S)."
     IDS_MSGJPN116           "アップロードは正常終了しました."
-    IDS_MSGJPN117           "完了"
-    IDS_MSGJPN118           "中止"
     IDS_MSGJPN119           "バイナリ"
     IDS_MSGJPN120           "アスキー"
     IDS_MSGJPN121           "無変換"
@@ -2676,6 +2674,8 @@ BEGIN
     IDS_NEED_EXSITING_WINSCP_INI 
                             "この機能で新規作成したINIファイルをWinSCPで読み込むと全ての設定が失われます.\nすでにWinSCPをお使いでありホストの設定のみ移行したい場合は既存のWinSCP.iniを選択してください."
     IDS_INVALID_PATH        "%s は不正なファイル名です.\r\nこのファイルはダウンロードされません."
+    IDS_FINISHED            "完了"
+    IDS_CANCELLED           "中止"
 END
 
 #endif    // Japanese (Japan) resources

--- a/Resource/resource.en-US.h
+++ b/Resource/resource.en-US.h
@@ -149,6 +149,8 @@
 #define IDS_FAIL_TO_EXPORT              230
 #define IDS_NEED_EXSITING_WINSCP_INI    231
 #define IDS_INVALID_PATH                232
+#define IDS_FINISHED                    233
+#define IDS_CANCELLED                   234
 #define TRANS_TIME_BAR                  1002
 #define TRANS_TEXT                      1003
 #define TRANS_REMOTE                    1003
@@ -592,8 +594,6 @@
 #define IDS_MSGJPN114                   10114
 #define IDS_MSGJPN115                   10115
 #define IDS_MSGJPN116                   10116
-#define IDS_MSGJPN117                   10117
-#define IDS_MSGJPN118                   10118
 #define IDS_MSGJPN119                   10119
 #define IDS_MSGJPN120                   10120
 #define IDS_MSGJPN121                   10121

--- a/Resource/resource.ja-JP.h
+++ b/Resource/resource.ja-JP.h
@@ -149,6 +149,8 @@
 #define IDS_FAIL_TO_EXPORT              230
 #define IDS_NEED_EXSITING_WINSCP_INI    231
 #define IDS_INVALID_PATH                232
+#define IDS_FINISHED                    233
+#define IDS_CANCELLED                   234
 #define TRANS_TIME_BAR                  1002
 #define TRANS_TEXT                      1003
 #define TRANS_REMOTE                    1003
@@ -592,8 +594,6 @@
 #define IDS_MSGJPN114                   10114
 #define IDS_MSGJPN115                   10115
 #define IDS_MSGJPN116                   10116
-#define IDS_MSGJPN117                   10117
-#define IDS_MSGJPN118                   10118
 #define IDS_MSGJPN119                   10119
 #define IDS_MSGJPN120                   10120
 #define IDS_MSGJPN121                   10121

--- a/mesg-jpn.h
+++ b/mesg-jpn.h
@@ -88,8 +88,6 @@ extern std::map<int, std::string> msgs;
 #define MSGJPN114 (std::data(msgs[10000+114])) /* アップロードを中止しました. */
 #define MSGJPN115 (std::data(msgs[10000+115])) /* アップロードは正常終了しました. (%d Sec. %d B/S). */
 #define MSGJPN116 (std::data(msgs[10000+116])) /* アップロードは正常終了しました. */
-#define MSGJPN117 (std::data(msgs[10000+117])) /* 完了 */
-#define MSGJPN118 (std::data(msgs[10000+118])) /* 中止 */
 #define MSGJPN133 (std::data(msgs[10000+133])) /* GMT%+02d:00 (日本) */
 #define MSGJPN145 (std::data(msgs[10000+145])) /* フォルダを変更できません. */
 #define MSGJPN146 (std::data(msgs[10000+146])) /* フォルダを作成できません. */


### PR DESCRIPTION
ファイル名が見切れていることがある。これは長さ計算の際にフォントを正しく設定していないため、実際の表示と一致しないことが原因。
転送ファイルサイズや転送速度がKB、KB/sまでしか対応していない。ネットワークの高速化に合わせてMB・GB表示にも対応する。