### PR TITLE
Drag&Dropでディレクトリを移動しないようにする

### DIFF
--- a/filelist.cpp
+++ b/filelist.cpp
@@ -327,7 +327,7 @@ static void doTransferRemoteFile(void)
 	MakeSelectedFileList(WIN_REMOTE, NO, NO, FileListBaseNoExpand, &CancelFlg);
 
 	// set temporary folder
-	auto& LocDir = AskLocalCurDir();
+	auto LocDir = AskLocalCurDir();
 
 	auto tmp = tempDirectory() / L"file";
 	if (auto const created = !fs::create_directory(tmp); !created) {


### PR DESCRIPTION
ディレクトリ名を参照の形で保持していたため、ディレクトリ移動の際に保持していたディレクトリ名も更新されていた。
ディレクトリ名のコピーを保持することで、ディレクトリ移動の影響を受けないようにする。 #210 で指摘の件。