### PR TITLE
Unicode taskwin

### DIFF
--- a/Resource/ffftp.en-US.rc
+++ b/Resource/ffftp.en-US.rc
@@ -2344,7 +2344,7 @@ BEGIN
     IDS_MSGJPN019           "Host %s not found."
     IDS_MSGJPN021           "SOCKS server %s not found."
     IDS_MSGJPN022           "Connecting to SOCKS server %s."
-    IDS_MSGJPN023           "Cannnot connect to SOCKS server. (Err=%d)"
+    IDS_MSGJPN023           "Cannnot connect to SOCKS server."
     IDS_MSGJPN025           "Connected."
     IDS_MSGJPN026           "Cannnot connected."
     IDS_MSGJPN027           "Cannnot create socket."
@@ -2587,7 +2587,7 @@ BEGIN
     IDS_MSGJPN280           "Cannnot get Data Socket"
     IDS_MSGJPN281           "Cannnot connect with PASV mode"
     IDS_MSGJPN282           "INI filename is not specified"
-    IDS_MSGJPN283           "INI file: "
+    IDS_MSGJPN283           "INI file: %s"
 END
 
 STRINGTABLE

--- a/Resource/ffftp.ja-JP.rc
+++ b/Resource/ffftp.ja-JP.rc
@@ -2308,7 +2308,7 @@ BEGIN
     IDS_MSGJPN019           "ホスト %s が見つかりません."
     IDS_MSGJPN021           "SOCKSサーバー %s が見つかりません."
     IDS_MSGJPN022           "SOCKSサーバー %s に接続しています."
-    IDS_MSGJPN023           "SOCKSサーバーに接続できません. (Err=%d)"
+    IDS_MSGJPN023           "SOCKSサーバーに接続できません."
     IDS_MSGJPN025           "接続しました."
     IDS_MSGJPN026           "接続できません."
     IDS_MSGJPN027           "ソケットが作成できません."
@@ -2551,7 +2551,7 @@ BEGIN
     IDS_MSGJPN280           "Dataソケットが取得できません"
     IDS_MSGJPN281           "PASVモードで接続できません"
     IDS_MSGJPN282           "INIファイル名が指定されていません"
-    IDS_MSGJPN283           "INIファイル指定: "
+    IDS_MSGJPN283           "INIファイル指定: %s"
 END
 
 STRINGTABLE

--- a/common.h
+++ b/common.h
@@ -776,6 +776,7 @@ void DeleteTaskWindow(void);
 HWND GetTaskWnd(void);
 void SetTaskMsg(_In_z_ _Printf_format_string_ const char* format, ...);
 void DispTaskMsg(void);
+void SetTaskMsg(UINT id, ...);
 void DoPrintf(_In_z_ _Printf_format_string_ const char* format, ...);
 void DoPrintf(_In_z_ _Printf_format_string_ const wchar_t* format, ...);
 

--- a/common.h
+++ b/common.h
@@ -777,6 +777,7 @@ HWND GetTaskWnd(void);
 void SetTaskMsg(_In_z_ _Printf_format_string_ const char* format, ...);
 void DispTaskMsg(void);
 void DoPrintf(_In_z_ _Printf_format_string_ const char* format, ...);
+void DoPrintf(_In_z_ _Printf_format_string_ const wchar_t* format, ...);
 
 /*===== hostman.c =====*/
 

--- a/common.h
+++ b/common.h
@@ -989,7 +989,7 @@ class CodeDetector {
 public:
 	void Test(std::string_view str);
 	int result() const {
-		DoPrintf("CodeDetector::result(): utf8 %d, sjis %d, euc %d, jis %d, nfc %d, nfd %d", utf8, sjis, euc, jis, int(nfc), int(nfd));
+		DoPrintf(L"CodeDetector::result(): utf8 %d, sjis %d, euc %d, jis %d, nfc %d, nfd %d", utf8, sjis, euc, jis, int(nfc), int(nfd));
 		auto [_, id] = std::max<std::tuple<int, int>>({
 			{ utf8, KANJI_UTF8N },
 			{ sjis, KANJI_SJIS },

--- a/common.h
+++ b/common.h
@@ -945,7 +945,7 @@ void SwitchOSSProc(void);
 int command(SOCKET cSkt, char* Reply, int* CancelCheckWork, _In_z_ _Printf_format_string_ const char* fmt, ...);
 std::tuple<int, std::string> ReadReplyMessage(SOCKET cSkt, int *CancelCheckWork);
 int ReadNchar(SOCKET cSkt, char *Buf, int Size, int *CancelCheckWork);
-void ReportWSError(const char* Msg, UINT Error);
+void ReportWSError(const wchar_t* functionName);
 
 /*===== getput.c =====*/
 

--- a/connect.cpp
+++ b/connect.cpp
@@ -1389,14 +1389,14 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, char *Host, char
 				{
 					Flg = 1;
 					if(setsockopt(ContSock, SOL_SOCKET, SO_OOBINLINE, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
-						ReportWSError("setsockopt", WSAGetLastError());
+						ReportWSError(L"setsockopt");
 					// データ転送用ソケットのTCP遅延転送が無効されているので念のため
 					if(setsockopt(ContSock, IPPROTO_TCP, TCP_NODELAY, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
-						ReportWSError("setsockopt", WSAGetLastError());
+						ReportWSError(L"setsockopt");
 //#pragma aaa
 					Flg = 1;
 					if(setsockopt(ContSock, SOL_SOCKET, SO_KEEPALIVE, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
-						ReportWSError("setsockopt", WSAGetLastError());
+						ReportWSError(L"setsockopt");
 					// 切断対策
 					if(TimeOut > 0)
 					{
@@ -1404,12 +1404,12 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, char *Host, char
 						KeepAlive.keepalivetime = TimeOut * 1000;
 						KeepAlive.keepaliveinterval = 1000;
 						if(WSAIoctl(ContSock, SIO_KEEPALIVE_VALS, &KeepAlive, sizeof(struct tcp_keepalive), NULL, 0, &dwTmp, NULL, NULL) == SOCKET_ERROR)
-							ReportWSError("WSAIoctl", WSAGetLastError());
+							ReportWSError(L"WSAIoctl");
 					}
 					LingerOpt.l_onoff = 1;
 					LingerOpt.l_linger = 90;
 					if(setsockopt(ContSock, SOL_SOCKET, SO_LINGER, (LPSTR)&LingerOpt, sizeof(LingerOpt)) == SOCKET_ERROR)
-						ReportWSError("setsockopt", WSAGetLastError());
+						ReportWSError(L"setsockopt");
 ///////
 
 
@@ -2098,12 +2098,12 @@ SOCKET GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork) {
 	sockaddr_storage saListen;
 	int salen = sizeof saListen;
 	if (getsockname(ctrl_skt, reinterpret_cast<sockaddr*>(&saListen), &salen) == SOCKET_ERROR) {
-		ReportWSError("getsockname", WSAGetLastError());
+		ReportWSError(L"getsockname");
 		return INVALID_SOCKET;
 	}
 	auto listen_skt = do_socket(saListen.ss_family, SOCK_STREAM, IPPROTO_TCP);
 	if (listen_skt == INVALID_SOCKET) {
-		ReportWSError("socket create", WSAGetLastError());
+		ReportWSError(L"socket create");
 		return INVALID_SOCKET;
 	}
 	if (AskHostFireWall() == YES && (FwallType == FWALL_SOCKS4 || FwallType == FWALL_SOCKS5_NOAUTH || FwallType == FWALL_SOCKS5_USER)) {
@@ -2111,7 +2111,7 @@ SOCKET GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork) {
 		// Control接続と同じアドレスに接続する
 		salen = sizeof saListen;
 		if (getpeername(ctrl_skt, reinterpret_cast<sockaddr*>(&saListen), &salen) == SOCKET_ERROR) {
-			ReportWSError("getpeername", WSAGetLastError());
+			ReportWSError(L"getpeername");
 			return INVALID_SOCKET;
 		}
 		if (do_connect(listen_skt, reinterpret_cast<const sockaddr*>(&saListen), salen, CancelCheckWork) == SOCKET_ERROR) {
@@ -2134,20 +2134,20 @@ SOCKET GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork) {
 		else
 			reinterpret_cast<sockaddr_in6&>(saListen).sin6_port = 0;
 		if (bind(listen_skt, reinterpret_cast<const sockaddr*>(&saListen), salen) == SOCKET_ERROR) {
-			ReportWSError("bind", WSAGetLastError());
+			ReportWSError(L"bind");
 			do_closesocket(listen_skt);
 			SetTaskMsg(MSGJPN027);
 			return INVALID_SOCKET;
 		}
 		salen = sizeof saListen;
 		if (getsockname(listen_skt, reinterpret_cast<sockaddr*>(&saListen), &salen) == SOCKET_ERROR) {
-			ReportWSError("getsockname", WSAGetLastError());
+			ReportWSError(L"getsockname");
 			do_closesocket(listen_skt);
 			SetTaskMsg(MSGJPN027);
 			return INVALID_SOCKET;
 		}
 		if (do_listen(listen_skt, 1) != 0) {
-			ReportWSError("listen", WSAGetLastError());
+			ReportWSError(L"listen");
 			do_closesocket(listen_skt);
 			SetTaskMsg(MSGJPN027);
 			return INVALID_SOCKET;

--- a/connect.cpp
+++ b/connect.cpp
@@ -1555,7 +1555,7 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, char *Host, char
 												if (HostData->NoDisplayUI == NO && InputDialog(re_passwd_dlg, GetMainHwnd(), NULL, Pass, PASSWORD_LEN+1))
 													Continue = YES;
 												else
-													DoPrintf("No password specified.");
+													DoPrintf(L"No password specified.");
 												ReInPass = YES;
 											}
 											else if(Sts == FTP_CONTINUE)
@@ -1567,13 +1567,13 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, char *Host, char
 													Sts = command(ContSock, NULL, CancelCheckWork, "ACCT %s", Acct) / 100;
 												}
 												else
-													DoPrintf("No account specified");
+													DoPrintf(L"No account specified");
 											}
 										}
 										else
 										{
 											Sts = FTP_ERROR;
-											DoPrintf("No password specified.");
+											DoPrintf(L"No password specified.");
 										}
 									}
 									// FTPES対応
@@ -1585,7 +1585,7 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, char *Host, char
 							else
 							{
 								Sts = FTP_ERROR;
-								DoPrintf("No user name specified");
+								DoPrintf(L"No user name specified");
 							}
 
 							if(Sts != FTP_COMPLETE)
@@ -1743,7 +1743,7 @@ static int CheckOneTimePassword(char *Pass, char *Reply, int Type)
 	if((Type == MD4) || (Type == MD5) || (Type == SHA1))
 	{
 		/* シーケンス番号を見つけるループ */
-		DoPrintf("Analyze OTP");
+		DoPrintf(L"Analyze OTP");
 		DoPrintf("%s", Pos);
 		Sts = FFFTP_FAIL;
 		while((Pos = GetNextField(Pos)) != NULL)
@@ -1751,7 +1751,7 @@ static int CheckOneTimePassword(char *Pass, char *Reply, int Type)
 			if(IsDigit(*Pos))
 			{
 				Seq = atoi(Pos);
-				DoPrintf("Sequence=%d", Seq);
+				DoPrintf(L"Sequence=%d", Seq);
 
 				/* Seed */
 				if((Pos = GetNextField(Pos)) != NULL)
@@ -1788,7 +1788,7 @@ static int CheckOneTimePassword(char *Pass, char *Reply, int Type)
 	else
 	{
 		strcpy(Reply, Pass);
-		DoPrintf("No OTP used.");
+		DoPrintf(L"No OTP used.");
 	}
 	return(Sts);
 }
@@ -1877,10 +1877,10 @@ static bool Socks5Authenticate(SOCKET s, int* CancelCheckWork) {
 		return false;
 	}
 	if (reply.METHOD == NO_AUTHENTICATION_REQUIRED)
-		DoPrintf("SOCKS5 No Authentication");
+		DoPrintf(L"SOCKS5 No Authentication");
 	else if (reply.METHOD == USERNAME_PASSWORD) {
 		// RFC 1929 Username/Password Authentication for SOCKS V5
-		DoPrintf("SOCKS5 User/Pass Authentication");
+		DoPrintf(L"SOCKS5 User/Pass Authentication");
 		auto ulen = (uint8_t)strlen(FwallUser);
 		auto plen = (uint8_t)strlen(FwallPass);
 		buffer = { 1 };												// VER
@@ -2107,7 +2107,7 @@ SOCKET GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork) {
 		return INVALID_SOCKET;
 	}
 	if (AskHostFireWall() == YES && (FwallType == FWALL_SOCKS4 || FwallType == FWALL_SOCKS5_NOAUTH || FwallType == FWALL_SOCKS5_USER)) {
-		DoPrintf("Use SOCKS BIND");
+		DoPrintf(L"Use SOCKS BIND");
 		// Control接続と同じアドレスに接続する
 		salen = sizeof saListen;
 		if (getpeername(ctrl_skt, reinterpret_cast<sockaddr*>(&saListen), &salen) == SOCKET_ERROR) {
@@ -2127,7 +2127,7 @@ SOCKET GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork) {
 			return INVALID_SOCKET;
 		}
 	} else {
-		DoPrintf("Use normal BIND");
+		DoPrintf(L"Use normal BIND");
 		// Control接続と同じアドレス（ただしport=0）でlistenする
 		if (saListen.ss_family == AF_INET)
 			reinterpret_cast<sockaddr_in&>(saListen).sin_port = 0;

--- a/connect.cpp
+++ b/connect.cpp
@@ -1922,7 +1922,7 @@ std::optional<sockaddr_storage> SocksReceiveReply(SOCKET s, int* CancelCheckWork
 		static_assert(sizeof reply == 8);
 		#pragma pack(pop)
 		if (!SocksRecv(s, reply, CancelCheckWork) || reply.VN != 0 || reply.CD != 90) {
-			DoPrintf(MSGJPN035);
+			SetTaskMsg(MSGJPN035);
 			return {};
 		}
 		// from "SOCKS: A protocol for TCP proxy across firewalls"

--- a/connect.cpp
+++ b/connect.cpp
@@ -205,7 +205,7 @@ void ConnectProc(int Type, int Num)
 			EnableUserOpe();
 		}
 		else
-			SetTaskMsg(MSGJPN001);
+			SetTaskMsg(IDS_MSGJPN001);
 	}
 	return;
 }
@@ -497,7 +497,7 @@ void HistoryConnectProc(int MenuCmd)
 			EnableUserOpe();
 		}
 		else
-			SetTaskMsg(MSGJPN002);
+			SetTaskMsg(IDS_MSGJPN002);
 	}
 	else
 		Sound::Error.Play();
@@ -958,7 +958,7 @@ int ReConnectTrnSkt(SOCKET *Skt, int *CancelCheckWork)
 
 	Sts = FFFTP_FAIL;
 
-	SetTaskMsg(MSGJPN003);
+	SetTaskMsg(IDS_MSGJPN003);
 
 //	DisableUserOpe();
 	/* 現在のソケットは切断 */
@@ -1013,7 +1013,7 @@ static int ReConnectSkt(SOCKET *Skt)
 
 	Sts = FFFTP_FAIL;
 
-	SetTaskMsg(MSGJPN003);
+	SetTaskMsg(IDS_MSGJPN003);
 
 	DisableUserOpe();
 	/* 現在のソケットは切断 */
@@ -1156,7 +1156,7 @@ void DisconnectProc(void)
 		SaveCurrentSetToHistory();
 
 		EraseRemoteDirForWnd();
-		SetTaskMsg(MSGJPN004);
+		SetTaskMsg(IDS_MSGJPN004);
 	}
 
 	TrnCtrlSocket = INVALID_SOCKET;
@@ -1189,7 +1189,7 @@ void DisconnectSet(void)
 	DispWindowTitle();
 	UpdateStatusBar();
 	MakeButtonsFocus();
-	SetTaskMsg(MSGJPN005);
+	SetTaskMsg(IDS_MSGJPN005);
 	return;
 }
 
@@ -1438,7 +1438,7 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, char *Host, char
 					}
 					if((Sts != FTP_COMPLETE) && (Sts != FTP_CONTINUE))
 					{
-						SetTaskMsg(MSGJPN006);
+						SetTaskMsg(IDS_MSGJPN006);
 						DoClose(ContSock);
 						ContSock = INVALID_SOCKET;
 					}
@@ -1464,7 +1464,7 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, char *Host, char
 
 						if((Sts != FTP_COMPLETE) && (Sts != FTP_CONTINUE))
 						{
-							SetTaskMsg(MSGJPN007, Host);
+							SetTaskMsg(IDS_MSGJPN007, u8(Host).c_str());
 							DoClose(ContSock);
 							ContSock = INVALID_SOCKET;
 						}
@@ -1590,7 +1590,7 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, char *Host, char
 
 							if(Sts != FTP_COMPLETE)
 							{
-								SetTaskMsg(MSGJPN008);
+								SetTaskMsg(IDS_MSGJPN008);
 								DoClose(ContSock);
 								ContSock = INVALID_SOCKET;
 							}
@@ -1604,8 +1604,7 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, char *Host, char
 				}
 				else
 				{
-//#pragma aaa
-					SetTaskMsg(MSGJPN009/*"接続できません(1) %x", ContSock*/);
+					SetTaskMsg(IDS_MSGJPN009);
 					DoClose(ContSock);
 					ContSock = INVALID_SOCKET;
 				}
@@ -1616,9 +1615,9 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, char *Host, char
 
 			if(((Fwall >= FWALL_FU_FP_SITE) && (Fwall <= FWALL_OPEN)) ||
 			   (Fwall == FWALL_FU_FP))
-				SetTaskMsg(MSGJPN010);
+				SetTaskMsg(IDS_MSGJPN010);
 			else
-				SetTaskMsg(MSGJPN011);
+				SetTaskMsg(IDS_MSGJPN011);
 		}
 
 #if 0
@@ -1672,19 +1671,19 @@ static SOCKET DoConnect(HOSTDATA* HostData, char *Host, char *User, char *Pass, 
 	*CancelCheckWork = NO;
 	if(*CancelCheckWork == NO && ContSock == INVALID_SOCKET && HostData->UseFTPIS == YES)
 	{
-		SetTaskMsg(MSGJPN316);
+		SetTaskMsg(IDS_MSGJPN316);
 		if((ContSock = DoConnectCrypt(CRYPT_FTPIS, HostData, Host, User, Pass, Acct, Port, Fwall, SavePass, Security, CancelCheckWork)) != INVALID_SOCKET)
 			HostData->CryptMode = CRYPT_FTPIS;
 	}
 	if(*CancelCheckWork == NO && ContSock == INVALID_SOCKET && HostData->UseFTPES == YES)
 	{
-		SetTaskMsg(MSGJPN315);
+		SetTaskMsg(IDS_MSGJPN315);
 		if((ContSock = DoConnectCrypt(CRYPT_FTPES, HostData, Host, User, Pass, Acct, Port, Fwall, SavePass, Security, CancelCheckWork)) != INVALID_SOCKET)
 			HostData->CryptMode = CRYPT_FTPES;
 	}
 	if(*CancelCheckWork == NO && ContSock == INVALID_SOCKET && HostData->UseNoEncryption == YES)
 	{
-		SetTaskMsg(MSGJPN314);
+		SetTaskMsg(IDS_MSGJPN314);
 		if((ContSock = DoConnectCrypt(CRYPT_NONE, HostData, Host, User, Pass, Acct, Port, Fwall, SavePass, Security, CancelCheckWork)) != INVALID_SOCKET)
 			HostData->CryptMode = CRYPT_NONE;
 	}
@@ -1724,17 +1723,17 @@ static int CheckOneTimePassword(char *Pass, char *Reply, int Type)
 		if((Pos = stristr(Reply, "otp-md5")) != NULL)
 		{
 			Type = MD5;
-			SetTaskMsg(MSGJPN012);
+			SetTaskMsg(IDS_MSGJPN012);
 		}
 		else if((Pos = stristr(Reply, "otp-sha1")) != NULL)
 		{
 			Type = SHA1;
-			SetTaskMsg(MSGJPN013);
+			SetTaskMsg(IDS_MSGJPN013);
 		}
 		else if(((Pos = stristr(Reply, "otp-md4")) != NULL) || ((Pos = stristr(Reply, "s/key")) != NULL))
 		{
 			Type = MD4;
-			SetTaskMsg(MSGJPN014);
+			SetTaskMsg(IDS_MSGJPN014);
 		}
 	}
 	else
@@ -1783,7 +1782,7 @@ static int CheckOneTimePassword(char *Pass, char *Reply, int Type)
 		}
 
 		if(Sts == FFFTP_FAIL)
-			SetTaskMsg(MSGJPN015);
+			SetTaskMsg(IDS_MSGJPN015);
 	}
 	else
 	{
@@ -1841,7 +1840,7 @@ enum class SocksCommand : uint8_t {
 
 static bool SocksSend(SOCKET s, std::vector<uint8_t> const& buffer, int* CancelCheckWork) {
 	if (SendData(s, reinterpret_cast<const char*>(data(buffer)), size_as<int>(buffer), 0, CancelCheckWork) != FFFTP_SUCCESS) {
-		SetTaskMsg(MSGJPN033, *reinterpret_cast<const short*>(&buffer[0]));
+		SetTaskMsg(IDS_MSGJPN033, *reinterpret_cast<const short*>(&buffer[0]));
 		return false;
 	}
 	return true;
@@ -1873,7 +1872,7 @@ static bool Socks5Authenticate(SOCKET s, int* CancelCheckWork) {
 	static_assert(sizeof reply == 2);
 	#pragma pack(pop)
 	if (!SocksSend(s, buffer, CancelCheckWork) || !SocksRecv(s, reply, CancelCheckWork)) {
-		SetTaskMsg(MSGJPN036);
+		SetTaskMsg(IDS_MSGJPN036);
 		return false;
 	}
 	if (reply.METHOD == NO_AUTHENTICATION_REQUIRED)
@@ -1896,11 +1895,11 @@ static bool Socks5Authenticate(SOCKET s, int* CancelCheckWork) {
 		static_assert(sizeof reply == 2);
 		#pragma pack(pop)
 		if (!SocksSend(s, buffer, CancelCheckWork) || !SocksRecv(s, reply, CancelCheckWork) || reply.STATUS != 0) {
-			SetTaskMsg(MSGJPN037);
+			SetTaskMsg(IDS_MSGJPN037);
 			return false;
 		}
 	} else {
-		SetTaskMsg(MSGJPN036);
+		SetTaskMsg(IDS_MSGJPN036);
 		return false;
 	}
 	return true;
@@ -1922,7 +1921,7 @@ std::optional<sockaddr_storage> SocksReceiveReply(SOCKET s, int* CancelCheckWork
 		static_assert(sizeof reply == 8);
 		#pragma pack(pop)
 		if (!SocksRecv(s, reply, CancelCheckWork) || reply.VN != 0 || reply.CD != 90) {
-			SetTaskMsg(MSGJPN035);
+			SetTaskMsg(IDS_MSGJPN035);
 			return {};
 		}
 		// from "SOCKS: A protocol for TCP proxy across firewalls"
@@ -1973,7 +1972,7 @@ std::optional<sockaddr_storage> SocksReceiveReply(SOCKET s, int* CancelCheckWork
 			}
 		}
 	}
-	SetTaskMsg(MSGJPN034);
+	SetTaskMsg(IDS_MSGJPN034);
 	return {};
 }
 
@@ -2032,36 +2031,38 @@ static std::optional<sockaddr_storage> SocksRequest(SOCKET s, SocksCommand cmd, 
 
 SOCKET connectsock(char *host, int port, char *PreMsg, int *CancelCheckWork) {
 	std::variant<sockaddr_storage, std::tuple<std::string, int>> target;
+	auto wHost = u8(host);
 	int Fwall = AskHostFireWall() == YES ? FwallType : FWALL_NONE;
-	if (auto ai = getaddrinfo(u8(host), port, Fwall == FWALL_SOCKS4 ? AF_INET : AF_UNSPEC)) {
+	if (auto ai = getaddrinfo(wHost, port, Fwall == FWALL_SOCKS4 ? AF_INET : AF_UNSPEC)) {
 		// ホスト名がIPアドレスだった
-		SetTaskMsg(MSGJPN017, PreMsg, host, u8(AddressPortToString(ai->ai_addr, ai->ai_addrlen)).c_str());
+		SetTaskMsg(IDS_MSGJPN017, u8(PreMsg).c_str(), wHost.c_str(), AddressPortToString(ai->ai_addr, ai->ai_addrlen).c_str());
 		memcpy(&std::get<sockaddr_storage>(target), ai->ai_addr, ai->ai_addrlen);
 	} else if ((Fwall == FWALL_SOCKS5_NOAUTH || Fwall == FWALL_SOCKS5_USER) && FwallResolve == YES) {
 		// SOCKS5で名前解決する
 		target = std::tuple{ std::string(host), port };
-	} else if (ai = getaddrinfo(u8(host), port, Fwall == FWALL_SOCKS4 ? AF_INET : AF_UNSPEC, CancelCheckWork)) {
+	} else if (ai = getaddrinfo(wHost, port, Fwall == FWALL_SOCKS4 ? AF_INET : AF_UNSPEC, CancelCheckWork)) {
 		// 名前解決に成功
-		SetTaskMsg(MSGJPN017, PreMsg, host, u8(AddressPortToString(ai->ai_addr, ai->ai_addrlen)).c_str());
+		SetTaskMsg(IDS_MSGJPN017, u8(PreMsg).c_str(), wHost.c_str(), AddressPortToString(ai->ai_addr, ai->ai_addrlen).c_str());
 		memcpy(&std::get<sockaddr_storage>(target), ai->ai_addr, ai->ai_addrlen);
 	} else {
 		// 名前解決に失敗
-		SetTaskMsg(MSGJPN019, host);
+		SetTaskMsg(IDS_MSGJPN019, wHost.c_str());
 		return INVALID_SOCKET;
 	}
 
 	sockaddr_storage saConnect;
 	if (Fwall == FWALL_SOCKS4 || Fwall == FWALL_SOCKS5_NOAUTH || Fwall == FWALL_SOCKS5_USER) {
 		// connectで接続する先はSOCKSサーバ
-		auto ai = getaddrinfo(u8(FwallHost), FwallPort);
+		auto wFwallHost = u8(FwallHost);
+		auto ai = getaddrinfo(wFwallHost, FwallPort);
 		if (!ai)
-			ai = getaddrinfo(u8(FwallHost), FwallPort, AF_UNSPEC, CancelCheckWork);
+			ai = getaddrinfo(wFwallHost, FwallPort, AF_UNSPEC, CancelCheckWork);
 		if (!ai) {
-			SetTaskMsg(MSGJPN021, FwallHost);
+			SetTaskMsg(IDS_MSGJPN021, wFwallHost.c_str());
 			return INVALID_SOCKET;
 		}
 		memcpy(&saConnect, ai->ai_addr, ai->ai_addrlen);
-		SetTaskMsg(MSGJPN022, u8(AddressPortToString(ai->ai_addr, ai->ai_addrlen)).c_str());
+		SetTaskMsg(IDS_MSGJPN022, AddressPortToString(ai->ai_addr, ai->ai_addrlen).c_str());
 	} else {
 		// connectで接続するのは接続先のホスト
 		saConnect = std::get<sockaddr_storage>(target);
@@ -2069,26 +2070,26 @@ SOCKET connectsock(char *host, int port, char *PreMsg, int *CancelCheckWork) {
 
 	auto s = do_socket(saConnect.ss_family, SOCK_STREAM, IPPROTO_TCP);
 	if (s == INVALID_SOCKET) {
-		SetTaskMsg(MSGJPN027);
+		SetTaskMsg(IDS_MSGJPN027);
 		return INVALID_SOCKET;
 	}
 	SetAsyncTableData(s, target);
 	if (do_connect(s, reinterpret_cast<const sockaddr*>(&saConnect), sizeof saConnect, CancelCheckWork) == SOCKET_ERROR) {
-		SetTaskMsg(MSGJPN026);
+		SetTaskMsg(IDS_MSGJPN026);
 		DoClose(s);
 		return INVALID_SOCKET;
 	}
 	if (Fwall == FWALL_SOCKS4 || Fwall == FWALL_SOCKS5_NOAUTH || Fwall == FWALL_SOCKS5_USER) {
 		auto result = SocksRequest(s, SocksCommand::Connect, target, CancelCheckWork);
 		if (!result) {
-			SetTaskMsg(MSGJPN023, -1);
+			SetTaskMsg(IDS_MSGJPN023);
 			DoClose(s);
 			return INVALID_SOCKET;
 		}
 		CurHost.CurNetType = result->ss_family == AF_INET ? NTYPE_IPV4 : NTYPE_IPV6;
 	} else
 		CurHost.CurNetType = saConnect.ss_family == AF_INET ? NTYPE_IPV4 : NTYPE_IPV6;
-	SetTaskMsg(MSGJPN025);
+	SetTaskMsg(IDS_MSGJPN025);
 	return s;
 }
 
@@ -2122,7 +2123,7 @@ SOCKET GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork) {
 		if (auto result = SocksRequest(listen_skt, SocksCommand::Bind, target, CancelCheckWork)) {
 			saListen = *result;
 		} else {
-			SetTaskMsg(MSGJPN023, -1);
+			SetTaskMsg(IDS_MSGJPN023);
 			DoClose(listen_skt);
 			return INVALID_SOCKET;
 		}
@@ -2136,20 +2137,20 @@ SOCKET GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork) {
 		if (bind(listen_skt, reinterpret_cast<const sockaddr*>(&saListen), salen) == SOCKET_ERROR) {
 			ReportWSError(L"bind");
 			do_closesocket(listen_skt);
-			SetTaskMsg(MSGJPN027);
+			SetTaskMsg(IDS_MSGJPN027);
 			return INVALID_SOCKET;
 		}
 		salen = sizeof saListen;
 		if (getsockname(listen_skt, reinterpret_cast<sockaddr*>(&saListen), &salen) == SOCKET_ERROR) {
 			ReportWSError(L"getsockname");
 			do_closesocket(listen_skt);
-			SetTaskMsg(MSGJPN027);
+			SetTaskMsg(IDS_MSGJPN027);
 			return INVALID_SOCKET;
 		}
 		if (do_listen(listen_skt, 1) != 0) {
 			ReportWSError(L"listen");
 			do_closesocket(listen_skt);
-			SetTaskMsg(MSGJPN027);
+			SetTaskMsg(IDS_MSGJPN027);
 			return INVALID_SOCKET;
 		}
 		// TODO: IPv6にUPnP NATは無意味なのでは？
@@ -2174,7 +2175,7 @@ SOCKET GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork) {
 		status = command(ctrl_skt, NULL, CancelCheckWork, "EPRT |2|%s|%d|", a.c_str(), ntohs(p));
 	}
 	if (status / 100 != FTP_COMPLETE) {
-		SetTaskMsg(MSGJPN031, saListen.ss_family == AF_INET ? "PORT" : "EPRT");
+		SetTaskMsg(IDS_MSGJPN031, saListen.ss_family == AF_INET ? L"PORT" : L"EPRT");
 		if (IsUPnPLoaded() == YES)
 			if (int port; GetAsyncTableDataMapPort(listen_skt, &port) == YES)
 				RemovePortMapping(port);

--- a/connect.cpp
+++ b/connect.cpp
@@ -1080,12 +1080,6 @@ void SktShareProh(void)
 {
 	if(CmdCtrlSocket == TrnCtrlSocket)
 	{
-
-//SetTaskMsg("############### SktShareProh");
-
-		// 同時接続対応
-//		CmdCtrlSocket = INVALID_SOCKET;
-//		ReConnectSkt(&CmdCtrlSocket);
 		if(CurHost.ReuseCmdSkt == YES)
 		{
 			CurHost.ReuseCmdSkt = NO;
@@ -1132,10 +1126,6 @@ int AskShareProh(void)
 
 void DisconnectProc(void)
 {
-
-//SetTaskMsg("############### Disconnect Cmd=%x, Trn=%x", CmdCtrlSocket,TrnCtrlSocket);
-
-	// 同時接続対応
 	AbortAllTransfer();
 
 	if((CmdCtrlSocket != INVALID_SOCKET) && (CmdCtrlSocket != TrnCtrlSocket))

--- a/filelist.cpp
+++ b/filelist.cpp
@@ -2496,7 +2496,7 @@ static void AddFileList(FILELIST const& Pkt, std::vector<FILELIST>& Base) {
 	DoPrintf("FileList : NODE=%d : %s", Pkt.Node, Pkt.File);
 	/* リストの重複を取り除く */
 	if (std::any_of(begin(Base), end(Base), [name = Pkt.File](auto const& f) { return strcmp(name, f.File) == 0; })) {
-		DoPrintf(" --> Duplicate!!");
+		DoPrintf(L" --> Duplicate!!");
 		return;
 	}
 	Base.emplace_back(Pkt);

--- a/filelist.cpp
+++ b/filelist.cpp
@@ -891,7 +891,7 @@ void GetRemoteDirForWnd(int Mode, int *CancelCheckWork) {
 				// 先頭のアイテムを選択
 				ListView_SetItemState(GetRemoteHwnd(), 0, LVIS_FOCUSED, LVIS_FOCUSED);
 			} else {
-				SetTaskMsg(MSGJPN048);
+				SetTaskMsg(IDS_MSGJPN048);
 				SendMessageW(GetRemoteHwnd(), LVM_DELETEALLITEMS, 0, 0);
 			}
 		} else {
@@ -900,7 +900,7 @@ void GetRemoteDirForWnd(int Mode, int *CancelCheckWork) {
 			 * ようにする(VIEWはクリアして良い) */
 			if (AskHostType() != HTYPE_VMS)
 #endif
-				SetTaskMsg(MSGJPN049);
+				SetTaskMsg(IDS_MSGJPN049);
 			SendMessageW(GetRemoteHwnd(), LVM_DELETEALLITEMS, 0, 0);
 		}
 		EnableUserOpe();

--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -646,7 +646,7 @@ static void DispMirrorFiles(std::vector<FILELIST> const& Local, std::vector<FILE
 
 	if(DebugConsole == YES)
 	{
-		DoPrintf("---- MIRROR FILE LIST ----");
+		DoPrintf(L"---- MIRROR FILE LIST ----");
 		for (auto const& f : Local) {
 			FileTimeToLocalFileTime(&f.Time, &fTime);
 			if (FileTimeToSystemTime(&fTime, &sTime))
@@ -663,7 +663,7 @@ static void DispMirrorFiles(std::vector<FILELIST> const& Local, std::vector<FILE
 				strcpy(Date, "");
 			DoPrintf("REMOTE : %s %s [%s] %s", f.Attr == 1 ? "YES" : "NO ", f.Node == NODE_DIR ? "DIR " : "FILE", Date, f.File);
 		}
-		DoPrintf("---- END ----");
+		DoPrintf(L"---- END ----");
 	}
 	return;
 }

--- a/getput.cpp
+++ b/getput.cpp
@@ -1134,7 +1134,7 @@ int DoDownload(SOCKET cSkt, TRANSPACKET& item, int DirList, int *CancelCheckWork
 	if(IsSpecialDevice(GetFileName(item.LocalFile)) == YES)
 	{
 		iRetCode = 500;
-		SetTaskMsg(MSGJPN085, GetFileName(item.LocalFile));
+		SetTaskMsg(IDS_MSGJPN085, u8(GetFileName(item.LocalFile)).c_str());
 	}
 	else if(item.Mode != EXIST_IGNORE)
 	{
@@ -1174,7 +1174,7 @@ int DoDownload(SOCKET cSkt, TRANSPACKET& item, int DirList, int *CancelCheckWork
 	else
 	{
 		DispTransFileInfo(item, MSGJPN088, TRUE, YES);
-		SetTaskMsg(MSGJPN089, item.RemoteFile);
+		SetTaskMsg(IDS_MSGJPN089, u8(item.RemoteFile).c_str());
 		iRetCode = 200;
 	}
 	return(iRetCode);
@@ -1262,7 +1262,7 @@ static int DownloadNonPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 			else
 			{
 				SetErrorMsg(Reply);
-				SetTaskMsg(MSGJPN090);
+				SetTaskMsg(IDS_MSGJPN090);
 				// UPnP対応
 				if(IsUPnPLoaded() == YES)
 				{
@@ -1360,7 +1360,7 @@ static int DownloadPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 					else
 					{
 						SetErrorMsg(Reply);
-						SetTaskMsg(MSGJPN092);
+						SetTaskMsg(IDS_MSGJPN092);
 						data_socket = DoClose(data_socket);
 						iRetCode = 500;
 					}
@@ -1374,7 +1374,7 @@ static int DownloadPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 		else
 		{
 			SetErrorMsg(MSGJPN093);
-			SetTaskMsg(MSGJPN093);
+			SetTaskMsg(IDS_MSGJPN093);
 			iRetCode = 500;
 		}
 	}
@@ -1437,7 +1437,7 @@ static int DownloadFile(TRANSPACKET *Pkt, SOCKET dSkt, int CreateMode, int *Canc
 			if (int timeout; (read = do_recv(dSkt, buf, BUFSIZE, 0, &timeout, CancelCheckWork)) <= 0) {
 				if (timeout == YES) {
 					SetErrorMsg(MSGJPN094);
-					SetTaskMsg(MSGJPN094);
+					SetTaskMsg(IDS_MSGJPN094);
 					if (Pkt->hWndTrans != NULL)
 						ClearAll = YES;
 					if (Pkt->Abort == ABORT_NONE)
@@ -1478,7 +1478,7 @@ static int DownloadFile(TRANSPACKET *Pkt, SOCKET dSkt, int CreateMode, int *Canc
 			ReportWSError(L"recv");
 	} else {
 		SetErrorMsg(MSGJPN095, Pkt->LocalFile);
-		SetTaskMsg(MSGJPN095, Pkt->LocalFile);
+		SetTaskMsg(IDS_MSGJPN095, u8(Pkt->LocalFile).c_str());
 		Pkt->Abort = ABORT_ERROR;
 	}
 
@@ -1497,7 +1497,7 @@ static int DownloadFile(TRANSPACKET *Pkt, SOCKET dSkt, int CreateMode, int *Canc
 	auto [code, text] = ReadReplyMessage(Pkt->ctrl_skt, CancelCheckWork);
 	if (Pkt->Abort == ABORT_DISKFULL) {
 		SetErrorMsg(MSGJPN096);
-		SetTaskMsg(MSGJPN096);
+		SetTaskMsg(IDS_MSGJPN096);
 	}
 	if (code / 100 >= FTP_RETRY)
 		SetErrorMsg(text.c_str());
@@ -1546,16 +1546,13 @@ static void DispDownloadFinishMsg(TRANSPACKET *Pkt, int iRetCode)
 //			if((strncmp(Pkt->Cmd, "NLST", 4) == 0) || (strncmp(Pkt->Cmd, "LIST", 4) == 0))
 			if((strncmp(Pkt->Cmd, "NLST", 4) == 0) || (strncmp(Pkt->Cmd, "LIST", 4) == 0) || (strncmp(Pkt->Cmd, "MLSD", 4) == 0))
 			{
-				SetTaskMsg(MSGJPN097);
+				SetTaskMsg(IDS_MSGJPN097);
 				strcpy(Fname, MSGJPN098);
 			}
-			// 同時接続対応
-//			else if((Pkt->hWndTrans != NULL) && (TimeStart != 0))
-//				SetTaskMsg(MSGJPN099, TimeStart, Pkt->ExistSize/TimeStart);
 			else if((Pkt->hWndTrans != NULL) && (TimeStart[Pkt->ThreadCount] != 0))
-				SetTaskMsg(MSGJPN099, TimeStart[Pkt->ThreadCount], Pkt->ExistSize/TimeStart[Pkt->ThreadCount]);
+				SetTaskMsg(IDS_MSGJPN099, TimeStart[Pkt->ThreadCount], Pkt->ExistSize/TimeStart[Pkt->ThreadCount]);
 			else
-				SetTaskMsg(MSGJPN100);
+				SetTaskMsg(IDS_MSGJPN100);
 
 			if(Pkt->Abort != ABORT_USER)
 			{
@@ -1588,17 +1585,11 @@ static void DispDownloadFinishMsg(TRANSPACKET *Pkt, int iRetCode)
 			// MLSD対応
 //			if((strncmp(Pkt->Cmd, "NLST", 4) == 0) || (strncmp(Pkt->Cmd, "LIST", 4) == 0))
 			if((strncmp(Pkt->Cmd, "NLST", 4) == 0) || (strncmp(Pkt->Cmd, "LIST", 4) == 0) || (strncmp(Pkt->Cmd, "MLSD", 4) == 0))
-				SetTaskMsg(MSGJPN101, Pkt->ExistSize);
-			// 同時接続対応
-//			else if((Pkt->hWndTrans != NULL) && (TimeStart != 0))
-//				SetTaskMsg(MSGJPN102, TimeStart, Pkt->ExistSize/TimeStart);
+				SetTaskMsg(IDS_MSGJPN101, Pkt->ExistSize);
 			else if((Pkt->hWndTrans != NULL) && (TimeStart[Pkt->ThreadCount] != 0))
-				// "0 B/S"と表示されるバグを修正
-				// 原因は%dにあたる部分に64ビット値が渡されているため
-//				SetTaskMsg(MSGJPN102, TimeStart[Pkt->ThreadCount], Pkt->ExistSize/TimeStart[Pkt->ThreadCount]);
-				SetTaskMsg(MSGJPN102, (LONG)TimeStart[Pkt->ThreadCount], (LONG)(Pkt->ExistSize/TimeStart[Pkt->ThreadCount]));
+				SetTaskMsg(IDS_MSGJPN102, (LONG)TimeStart[Pkt->ThreadCount], (LONG)(Pkt->ExistSize/TimeStart[Pkt->ThreadCount]));
 			else
-				SetTaskMsg(MSGJPN103, Pkt->ExistSize);
+				SetTaskMsg(IDS_MSGJPN103, Pkt->ExistSize);
 		}
 	}
 	return;
@@ -1748,7 +1739,7 @@ static int DoUpload(SOCKET cSkt, TRANSPACKET& item)
 		else
 		{
 			SetErrorMsg(MSGJPN105, item.LocalFile);
-			SetTaskMsg(MSGJPN105, item.LocalFile);
+			SetTaskMsg(IDS_MSGJPN105, u8(item.LocalFile).c_str());
 			iRetCode = 500;
 			item.Abort = ABORT_ERROR;
 		}
@@ -1757,7 +1748,7 @@ static int DoUpload(SOCKET cSkt, TRANSPACKET& item)
 	else
 	{
 		DispTransFileInfo(item, MSGJPN106, TRUE, YES);
-		SetTaskMsg(MSGJPN107, item.LocalFile);
+		SetTaskMsg(IDS_MSGJPN107, u8(item.LocalFile).c_str());
 		iRetCode = 200;
 	}
 	return(iRetCode);
@@ -1866,7 +1857,7 @@ static int UploadNonPassive(TRANSPACKET *Pkt)
 		else
 		{
 			SetErrorMsg(Reply);
-			SetTaskMsg(MSGJPN108);
+			SetTaskMsg(IDS_MSGJPN108);
 			// UPnP対応
 			if(IsUPnPLoaded() == YES)
 			{
@@ -1985,7 +1976,7 @@ static int UploadPassive(TRANSPACKET *Pkt)
 				else
 				{
 					SetErrorMsg(Reply);
-					SetTaskMsg(MSGJPN110);
+					SetTaskMsg(IDS_MSGJPN110);
 					data_socket = DoClose(data_socket);
 					iRetCode = 500;
 				}
@@ -1999,7 +1990,7 @@ static int UploadPassive(TRANSPACKET *Pkt)
 		else
 		{
 			SetErrorMsg(Buf);
-			SetTaskMsg(MSGJPN111);
+			SetTaskMsg(IDS_MSGJPN111);
 			iRetCode = 500;
 		}
 	}
@@ -2081,7 +2072,7 @@ static int UploadFile(TRANSPACKET *Pkt, SOCKET dSkt) {
 		}
 	} else {
 		SetErrorMsg(MSGJPN112, Pkt->LocalFile);
-		SetTaskMsg(MSGJPN112, Pkt->LocalFile);
+		SetTaskMsg(IDS_MSGJPN112, u8(Pkt->LocalFile).c_str());
 		Pkt->Abort = ABORT_ERROR;
 	}
 
@@ -2127,13 +2118,10 @@ static void DispUploadFinishMsg(TRANSPACKET *Pkt, int iRetCode)
 	{
 		if((iRetCode/100) >= FTP_CONTINUE)
 		{
-			// 同時接続対応
-//			if((Pkt->hWndTrans != NULL) && (TimeStart != 0))
-//				SetTaskMsg(MSGJPN113, TimeStart, Pkt->ExistSize/TimeStart);
 			if((Pkt->hWndTrans != NULL) && (TimeStart[Pkt->ThreadCount] != 0))
-				SetTaskMsg(MSGJPN113, TimeStart[Pkt->ThreadCount], Pkt->ExistSize/TimeStart[Pkt->ThreadCount]);
+				SetTaskMsg(IDS_MSGJPN113, TimeStart[Pkt->ThreadCount], Pkt->ExistSize/TimeStart[Pkt->ThreadCount]);
 			else
-				SetTaskMsg(MSGJPN114);
+				SetTaskMsg(IDS_MSGJPN114);
 
 			if(Pkt->Abort != ABORT_USER)
 			{
@@ -2163,16 +2151,10 @@ static void DispUploadFinishMsg(TRANSPACKET *Pkt, int iRetCode)
 		}
 		else
 		{
-			// 同時接続対応
-//			if((Pkt->hWndTrans != NULL) && (TimeStart != 0))
-//				SetTaskMsg(MSGJPN115, TimeStart, Pkt->ExistSize/TimeStart);
 			if((Pkt->hWndTrans != NULL) && (TimeStart[Pkt->ThreadCount] != 0))
-				// "0 B/S"と表示されるバグを修正
-				// 原因は%dにあたる部分に64ビット値が渡されているため
-//				SetTaskMsg(MSGJPN115, TimeStart[Pkt->ThreadCount], Pkt->ExistSize/TimeStart[Pkt->ThreadCount]);
-				SetTaskMsg(MSGJPN115, (LONG)TimeStart[Pkt->ThreadCount], (LONG)(Pkt->ExistSize/TimeStart[Pkt->ThreadCount]));
+				SetTaskMsg(IDS_MSGJPN115, (LONG)TimeStart[Pkt->ThreadCount], (LONG)(Pkt->ExistSize/TimeStart[Pkt->ThreadCount]));
 			else
-				SetTaskMsg(MSGJPN116);
+				SetTaskMsg(IDS_MSGJPN116);
 		}
 	}
 	return;

--- a/getput.cpp
+++ b/getput.cpp
@@ -1222,7 +1222,7 @@ static int DownloadNonPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 					data_socket = do_accept(listen_socket, reinterpret_cast<sockaddr*>(&sa), &salen);
 
 					if(shutdown(listen_socket, 1) != 0)
-						ReportWSError("shutdown listen", WSAGetLastError());
+						ReportWSError(L"shutdown listen");
 					// UPnP対応
 					if(IsUPnPLoaded() == YES)
 					{
@@ -1234,7 +1234,7 @@ static int DownloadNonPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 					if(data_socket == INVALID_SOCKET)
 					{
 						SetErrorMsg(MSGJPN280);
-						ReportWSError("accept", WSAGetLastError());
+						ReportWSError(L"accept");
 						iRetCode = 500;
 					}
 					else
@@ -1334,7 +1334,7 @@ static int DownloadPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 				// 変数が未初期化のバグ修正
 				Flg = 1;
 				if(setsockopt(data_socket, IPPROTO_TCP, TCP_NODELAY, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
-					ReportWSError("setsockopt", WSAGetLastError());
+					ReportWSError(L"setsockopt");
 
 				if(SetDownloadResume(Pkt, Pkt->Mode, Pkt->ExistSize, &CreateMode, CancelCheckWork) == YES)
 				{
@@ -1475,7 +1475,7 @@ static int DownloadFile(TRANSPACKET *Pkt, SOCKET dSkt, int CreateMode, int *Canc
 		}
 
 		if (read == SOCKET_ERROR)
-			ReportWSError("recv", WSAGetLastError());
+			ReportWSError(L"recv");
 	} else {
 		SetErrorMsg(MSGJPN095, Pkt->LocalFile);
 		SetTaskMsg(MSGJPN095, Pkt->LocalFile);
@@ -1483,7 +1483,7 @@ static int DownloadFile(TRANSPACKET *Pkt, SOCKET dSkt, int CreateMode, int *Canc
 	}
 
 	if (shutdown(dSkt, 1) != 0)
-		ReportWSError("shutdown", WSAGetLastError());
+		ReportWSError(L"shutdown");
 	LastDataConnectionTime = time(NULL);
 	DoClose(dSkt);
 
@@ -1826,7 +1826,7 @@ static int UploadNonPassive(TRANSPACKET *Pkt)
 				data_socket = do_accept(listen_socket, reinterpret_cast<sockaddr*>(&sa), &salen);
 
 				if(shutdown(listen_socket, 1) != 0)
-					ReportWSError("shutdown listen", WSAGetLastError());
+					ReportWSError(L"shutdown listen");
 				// UPnP対応
 				if(IsUPnPLoaded() == YES)
 				{
@@ -1838,7 +1838,7 @@ static int UploadNonPassive(TRANSPACKET *Pkt)
 				if(data_socket == INVALID_SOCKET)
 				{
 					SetErrorMsg(MSGJPN280);
-					ReportWSError("accept", WSAGetLastError());
+					ReportWSError(L"accept");
 					iRetCode = 500;
 				}
 				else
@@ -1939,7 +1939,7 @@ static int UploadPassive(TRANSPACKET *Pkt)
 				// 変数が未初期化のバグ修正
 				Flg = 1;
 				if(setsockopt(data_socket, IPPROTO_TCP, TCP_NODELAY, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
-					ReportWSError("setsockopt", WSAGetLastError());
+					ReportWSError(L"setsockopt");
 
 				SetUploadResume(Pkt, Pkt->Mode, Pkt->ExistSize, &Resume);
 				if(Resume == NO)
@@ -2087,7 +2087,7 @@ static int UploadFile(TRANSPACKET *Pkt, SOCKET dSkt) {
 
 	LastDataConnectionTime = time(NULL);
 	if (shutdown(dSkt, 1) != 0)
-		ReportWSError("shutdown", WSAGetLastError());
+		ReportWSError(L"shutdown");
 
 	auto [code, text] = ReadReplyMessage(Pkt->ctrl_skt, &Canceled[Pkt->ThreadCount]);
 	if (code / 100 >= FTP_RETRY)

--- a/getput.cpp
+++ b/getput.cpp
@@ -1238,7 +1238,7 @@ static int DownloadNonPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 						iRetCode = 500;
 					}
 					else
-						DoPrintf("Skt=%zu : accept from %s", data_socket, u8(AddressPortToString(&sa, salen)).c_str());
+						DoPrintf(L"Skt=%zu : accept from %s", data_socket, AddressPortToString(&sa, salen).c_str());
 				}
 
 				if(data_socket != INVALID_SOCKET)
@@ -1842,7 +1842,7 @@ static int UploadNonPassive(TRANSPACKET *Pkt)
 					iRetCode = 500;
 				}
 				else
-					DoPrintf("Skt=%zu : accept from %s", data_socket, u8(AddressPortToString(&sa, salen)).c_str());
+					DoPrintf(L"Skt=%zu : accept from %s", data_socket, AddressPortToString(&sa, salen).c_str());
 			}
 
 			if(data_socket != INVALID_SOCKET)

--- a/local.cpp
+++ b/local.cpp
@@ -37,7 +37,7 @@ int DoLocalCWD(const char *Path) {
 	fs::current_path(fs::u8path(Path), ec);
 	if (!ec)
 		return FFFTP_SUCCESS;
-	SetTaskMsg(MSGJPN145);
+	SetTaskMsg(IDS_MSGJPN145);
 	return FFFTP_FAIL;
 }
 
@@ -46,7 +46,7 @@ int DoLocalCWD(const char *Path) {
 void DoLocalMKD(const char* Path) {
 	SetTaskMsg(">>MKDIR %s", Path);
 	if (std::error_code ec; !fs::create_directory(fs::u8path(Path), ec))
-		SetTaskMsg(MSGJPN146);
+		SetTaskMsg(IDS_MSGJPN146);
 }
 
 
@@ -60,7 +60,7 @@ void DoLocalPWD(char *Buf) {
 void DoLocalRMD(const char* Path) {
 	SetTaskMsg(">>RMDIR %s", Path);
 	if (MoveFileToTrashCan(Path) != 0)
-		SetTaskMsg(MSGJPN148);
+		SetTaskMsg(IDS_MSGJPN148);
 }
 
 
@@ -68,7 +68,7 @@ void DoLocalRMD(const char* Path) {
 void DoLocalDELE(const char* Path) {
 	SetTaskMsg(">>DEL %s", Path);
 	if (MoveFileToTrashCan(Path) != 0)
-		SetTaskMsg(MSGJPN150);
+		SetTaskMsg(IDS_MSGJPN150);
 }
 
 
@@ -78,7 +78,7 @@ void DoLocalRENAME(const char *Src, const char *Dst) {
 	std::error_code ec;
 	fs::rename(fs::u8path(Src), fs::u8path(Dst), ec);
 	if (ec)
-		SetTaskMsg(MSGJPN151);
+		SetTaskMsg(IDS_MSGJPN151);
 }
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -516,7 +516,7 @@ static int InitApp(int cmdShow)
 
 				if(MakeTransferThread() == FFFTP_SUCCESS)
 				{
-					DoPrintf("DEBUG MESSAGE ON ! ##");
+					DoPrintf(L"DEBUG MESSAGE ON ! ##");
 
 					DispWindowTitle();
 					UpdateStatusBar();
@@ -528,7 +528,7 @@ static int InitApp(int cmdShow)
 					if(ForceIni)
 						SetTaskMsg("%s%s", MSGJPN283, IniPath.u8string().c_str());
 
-					DoPrintf("Help=%s", helpPath().u8string().c_str());
+					DoPrintf(L"Help=%s", helpPath().c_str());
 
 					DragAcceptFiles(GetRemoteHwnd(), TRUE);
 					DragAcceptFiles(GetLocalHwnd(), TRUE);
@@ -2121,18 +2121,18 @@ void ExecViewer(char *Fname, int App) {
 	auto pFname = fs::u8path(Fname);
 	if (wchar_t result[MAX_PATH]; App == -1 && pFname.has_extension() && FindExecutableW(pFname.c_str(), nullptr, result) > (HINSTANCE)32) {
 		// 拡張子があるので関連付けを実行する
-		DoPrintf("ShellExecute - %s", Fname);
+		DoPrintf(L"ShellExecute - %s", pFname.c_str());
 		ShellExecuteW(0, L"open", pFname.c_str(), nullptr, AskLocalCurDir().c_str(), SW_SHOW);
 	} else if (App == -1 && (GetFileAttributesW(pFname.c_str()) & FILE_ATTRIBUTE_DIRECTORY)) {
 		// ディレクトリなのでフォルダを開く
 		MakeDistinguishableFileName(ComLine, Fname);
-		DoPrintf("ShellExecute - %s", Fname);
+		DoPrintf(L"ShellExecute - %s", pFname.c_str());
 		ShellExecuteW(0, L"open", u8(ComLine).c_str(), nullptr, pFname.c_str(), SW_SHOW);
 	} else {
 		sprintf(ComLine, "%s \"%s\"", ViewerName[App == -1 ? 0 : App], Fname);
-		DoPrintf("CreateProcess - %s", ComLine);
-		STARTUPINFOW si{ sizeof(STARTUPINFOW), nullptr, nullptr, nullptr, 0, 0, 0, 0, 0, 0, 0, 0, SW_SHOWNORMAL };
 		auto wComLine = u8(ComLine);
+		DoPrintf(L"CreateProcess - %s", wComLine.c_str());
+		STARTUPINFOW si{ sizeof(STARTUPINFOW), nullptr, nullptr, nullptr, 0, 0, 0, 0, 0, 0, 0, 0, SW_SHOWNORMAL };
 		if (ProcessInformation pi; !CreateProcessW(nullptr, data(wComLine), nullptr, nullptr, false, 0, nullptr, systemDirectory().c_str(), &si, &pi)) {
 			SetTaskMsg(MSGJPN182, GetLastError());
 			SetTaskMsg(">>%s", ComLine);
@@ -2167,11 +2167,11 @@ void ExecViewer2(char *Fname1, char *Fname2, int App)
 		sprintf(ComLine, "%s %s %s", AssocProg, Fname1, Fname2);
 	else
 		sprintf(ComLine, "%s \"%s\" \"%s\"", AssocProg, Fname1, Fname2);
+	auto wComLine = u8(ComLine);
 
-	DoPrintf("FindExecutable - %s", ComLine);
+	DoPrintf(L"FindExecutable - %s", wComLine.c_str());
 
 	STARTUPINFOW si{ sizeof(STARTUPINFOW), nullptr, nullptr, nullptr, 0, 0, 0, 0, 0, 0, 0, 0, SW_SHOWNORMAL };
-	auto wComLine = u8(ComLine);
 	if (ProcessInformation pi; !CreateProcessW(nullptr, data(wComLine), nullptr, nullptr, false, 0, nullptr, systemDirectory().c_str(), &si, &pi)) {
 		SetTaskMsg(MSGJPN182, GetLastError());
 		SetTaskMsg(">>%s", ComLine);

--- a/main.cpp
+++ b/main.cpp
@@ -526,7 +526,7 @@ static int InitApp(int cmdShow)
 					);
 
 					if(ForceIni)
-						SetTaskMsg("%s%s", MSGJPN283, IniPath.u8string().c_str());
+						SetTaskMsg(IDS_MSGJPN283, IniPath.c_str());
 
 					DoPrintf(L"Help=%s", helpPath().c_str());
 
@@ -543,16 +543,16 @@ static int InitApp(int cmdShow)
 
 					/* セキュリティ警告文の表示 */
 					if( useDefautPassword ){
-						SetTaskMsg(MSGJPN300);
+						SetTaskMsg(IDS_MSGJPN300);
 					}
 					
 					/* パスワード不一致警告文の表示 */
 					switch( GetMasterPasswordStatus() ){
 					case PASSWORD_UNMATCH:
-						SetTaskMsg(MSGJPN301);
+						SetTaskMsg(IDS_MSGJPN301);
 						break;
 					case BAD_PASSWORD_HASH:
-						SetTaskMsg(MSGJPN302);
+						SetTaskMsg(IDS_MSGJPN302);
 						break;
 					default:
 						break;
@@ -1272,7 +1272,7 @@ static LRESULT CALLBACK FtpWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARA
 						if (!Dialog(GetFtpInst(), forcepasschange_dlg, hWnd))
 							break;
 						if(EnterMasterPasswordAndSet(true, hWnd) != 0)
-							SetTaskMsg(MSGJPN303);
+							SetTaskMsg(IDS_MSGJPN303);
 					}
 					else if(GetMasterPasswordStatus() == PASSWORD_OK)
 					{
@@ -1286,7 +1286,7 @@ static LRESULT CALLBACK FtpWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARA
 						}
 						if(GetMasterPasswordStatus() == PASSWORD_OK && EnterMasterPasswordAndSet(true, hWnd) != 0)
 						{
-							SetTaskMsg(MSGJPN303);
+							SetTaskMsg(IDS_MSGJPN303);
 							SaveRegistry();
 						}
 						else
@@ -1625,11 +1625,11 @@ static void StartupProc(std::vector<std::wstring_view> const& args) {
 		} else if (!empty(hostname) && empty(unc)) {
 			auto u8hostname = u8(hostname);
 			if (int AutoConnect = SearchHostName(data(u8hostname)); AutoConnect == -1)
-				__pragma(warning(suppress:4474)) SetTaskMsg(MSGJPN177, u8hostname.c_str());
+				SetTaskMsg(IDS_MSGJPN177, hostname.c_str());
 			else
 				PostMessageW(GetMainHwnd(), WM_COMMAND, MAKEWPARAM(MENU_CONNECT_NUM, opt), (LPARAM)AutoConnect);
 		} else {
-			SetTaskMsg(MSGJPN179);
+			SetTaskMsg(IDS_MSGJPN179);
 		}
 	}
 }
@@ -1666,24 +1666,25 @@ static std::optional<int> AnalyzeComLine(std::vector<std::wstring_view> const& a
 				option |= mapit->second;
 			} else if (key == L"-n"sv || key == L"--ini"sv) {
 				if (++it == end(args)) {
-					SetTaskMsg(MSGJPN282);
+					SetTaskMsg(IDS_MSGJPN282);
 					return {};
 				}
 			} else if (key == L"-z"sv || key == L"--mpasswd"sv) {
 				if (++it == end(args)) {
-					SetTaskMsg(MSGJPN299);
+					SetTaskMsg(IDS_MSGJPN299);
 					return {};
 				}
 			} else if (key == L"-s"sv || key == L"--set"sv) {
 				if (++it == end(args)) {
-					SetTaskMsg(MSGJPN178);
+					SetTaskMsg(IDS_MSGJPN178);
 					return {};
 				}
 				hostname = *it;
 			} else if (key == L"-h"sv || key == L"--help"sv) {
 				ShowHelp(IDH_HELP_TOPIC_0000024);
 			} else {
-				__pragma(warning(suppress:4474)) SetTaskMsg(MSGJPN180, u8(*it).c_str());
+				// argsはargvを指しておりnull terminatedである。
+				SetTaskMsg(IDS_MSGJPN180, it->data());
 				return {};
 			}
 		} else
@@ -2134,7 +2135,7 @@ void ExecViewer(char *Fname, int App) {
 		DoPrintf(L"CreateProcess - %s", wComLine.c_str());
 		STARTUPINFOW si{ sizeof(STARTUPINFOW), nullptr, nullptr, nullptr, 0, 0, 0, 0, 0, 0, 0, 0, SW_SHOWNORMAL };
 		if (ProcessInformation pi; !CreateProcessW(nullptr, data(wComLine), nullptr, nullptr, false, 0, nullptr, systemDirectory().c_str(), &si, &pi)) {
-			SetTaskMsg(MSGJPN182, GetLastError());
+			SetTaskMsg(IDS_MSGJPN182, GetLastError());
 			SetTaskMsg(">>%s", ComLine);
 		}
 	}
@@ -2173,7 +2174,7 @@ void ExecViewer2(char *Fname1, char *Fname2, int App)
 
 	STARTUPINFOW si{ sizeof(STARTUPINFOW), nullptr, nullptr, nullptr, 0, 0, 0, 0, 0, 0, 0, 0, SW_SHOWNORMAL };
 	if (ProcessInformation pi; !CreateProcessW(nullptr, data(wComLine), nullptr, nullptr, false, 0, nullptr, systemDirectory().c_str(), &si, &pi)) {
-		SetTaskMsg(MSGJPN182, GetLastError());
+		SetTaskMsg(IDS_MSGJPN182, GetLastError());
 		SetTaskMsg(">>%s", ComLine);
 	}
 }

--- a/mesg-jpn.h
+++ b/mesg-jpn.h
@@ -1,36 +1,5 @@
 ﻿#pragma once
 extern std::map<int, std::string> msgs;
-#define MSGJPN001 (std::data(msgs[10000+1])) /* 接続を中止しました. */
-#define MSGJPN002 (std::data(msgs[10000+2])) /* 接続を中止しました. */
-#define MSGJPN003 (std::data(msgs[10000+3])) /* \r\n再接続します.\r\n */
-#define MSGJPN004 (std::data(msgs[10000+4])) /* 切断しました */
-#define MSGJPN005 (std::data(msgs[10000+5])) /* 接続が切断されました. */
-#define MSGJPN006 (std::data(msgs[10000+6])) /* FireWallにログインできません. */
-#define MSGJPN007 (std::data(msgs[10000+7])) /* ホスト %s に接続できません. */
-#define MSGJPN008 (std::data(msgs[10000+8])) /* ログインできません. */
-#define MSGJPN009 (std::data(msgs[10000+9])) /* 接続できません. */
-#define MSGJPN010 (std::data(msgs[10000+10])) /* FireWallのホスト名が設定されていません. */
-#define MSGJPN011 (std::data(msgs[10000+11])) /* ホスト名がありません. */
-#define MSGJPN012 (std::data(msgs[10000+12])) /* MD5を使用します. */
-#define MSGJPN013 (std::data(msgs[10000+13])) /* SHA-1を使用します. */
-#define MSGJPN014 (std::data(msgs[10000+14])) /* MD4(S/KEY)を使用します. */
-#define MSGJPN015 (std::data(msgs[10000+15])) /* ワンタイムパスワードが処理できません */
-#define MSGJPN017 (std::data(msgs[10000+17])) /* %sホスト %s (%s) に接続しています. */
-#define MSGJPN019 (std::data(msgs[10000+19])) /* ホスト %s が見つかりません. */
-#define MSGJPN021 (std::data(msgs[10000+21])) /* SOCKSサーバー %s が見つかりません. */
-#define MSGJPN022 (std::data(msgs[10000+22])) /* SOCKSサーバー %s に接続しています. */
-#define MSGJPN023 (std::data(msgs[10000+23])) /* SOCKSサーバーに接続できません. (Err=%d) */
-#define MSGJPN025 (std::data(msgs[10000+25])) /* 接続しました. */
-#define MSGJPN026 (std::data(msgs[10000+26])) /* 接続できません. */
-#define MSGJPN027 (std::data(msgs[10000+27])) /* ソケットが作成できません. */
-#define MSGJPN031 (std::data(msgs[10000+31])) /* %sコマンドが受け付けられません. */
-#define MSGJPN033 (std::data(msgs[10000+33])) /* SOCKSのコマンドが送れませんでした (Cmd = %04X) */
-#define MSGJPN034 (std::data(msgs[10000+34])) /* SOCKS5のコマンドに対するリプライが受信できませんでした */
-#define MSGJPN035 (std::data(msgs[10000+35])) /* SOCKS4のコマンドに対するリプライが受信できませんでした */
-#define MSGJPN036 (std::data(msgs[10000+36])) /* SOCKSサーバーの認証方式が異なります. */
-#define MSGJPN037 (std::data(msgs[10000+37])) /* SOCKSサーバーに認証されませんでした. */
-#define MSGJPN048 (std::data(msgs[10000+48])) /* テンポラリファイルが読み出せません. */
-#define MSGJPN049 (std::data(msgs[10000+49])) /* ファイル一覧の取得に失敗しました. */
 #define MSGJPN050 (std::data(msgs[10000+50])) /* 検索（ローカル） */
 #define MSGJPN051 (std::data(msgs[10000+51])) /* 検索（ホスト） */
 #define MSGJPN052 (std::data(msgs[10000+52])) /* 削除: %s */
@@ -56,62 +25,28 @@ extern std::map<int, std::string> msgs;
 #define MSGJPN082 (std::data(msgs[10000+82])) /* フォルダ作成 */
 #define MSGJPN083 (std::data(msgs[10000+83])) /* フォルダ削除 */
 #define MSGJPN084 (std::data(msgs[10000+84])) /* ファイル削除 */
-#define MSGJPN085 (std::data(msgs[10000+85])) /* %sという名前のファイルはダウンロードできません. */
 #define MSGJPN086 (std::data(msgs[10000+86])) /* ダウンロード */
 #define MSGJPN087 (std::data(msgs[10000+87])) /* ファイル一覧取得 */
 #define MSGJPN088 (std::data(msgs[10000+88])) /* スキップ */
-#define MSGJPN089 (std::data(msgs[10000+89])) /* ファイル %s はスキップします. */
-#define MSGJPN090 (std::data(msgs[10000+90])) /* コマンドが受け付けられません. */
 #define MSGJPN091 (std::data(msgs[10000+91])) /* ダウンロードのために */
-#define MSGJPN092 (std::data(msgs[10000+92])) /* コマンドが受け付けられません. */
 #define MSGJPN093 (std::data(msgs[10000+93])) /* アドレスが取得できません. */
 #define MSGJPN094 (std::data(msgs[10000+94])) /* 受信はタイムアウトで失敗しました. */
 #define MSGJPN095 (std::data(msgs[10000+95])) /* ファイル %s が作成できません. */
 #define MSGJPN096 (std::data(msgs[10000+96])) /* ディスクがいっぱいで書き込めません. */
-#define MSGJPN097 (std::data(msgs[10000+97])) /* ファイル一覧の取得を中止しました. */
 #define MSGJPN098 (std::data(msgs[10000+98])) /* ファイル一覧 */
-#define MSGJPN099 (std::data(msgs[10000+99])) /* ダウンロードを中止しました. (%lld Sec. %lld B/S). */
-#define MSGJPN100 (std::data(msgs[10000+100])) /* ダウンロードを中止しました. */
-#define MSGJPN101 (std::data(msgs[10000+101])) /* ファイル一覧の取得は正常終了しました. (%lld Bytes) */
-#define MSGJPN102 (std::data(msgs[10000+102])) /* ダウンロードは正常終了しました. (%d Sec. %d B/S). */
-#define MSGJPN103 (std::data(msgs[10000+103])) /* ダウンロードは正常終了しました. (%lld Bytes) */
 #define MSGJPN104 (std::data(msgs[10000+104])) /* アップロード */
 #define MSGJPN105 (std::data(msgs[10000+105])) /* ファイル %s が読み出せません. */
 #define MSGJPN106 (std::data(msgs[10000+106])) /* スキップ */
-#define MSGJPN107 (std::data(msgs[10000+107])) /* ファイル %s はスキップします. */
-#define MSGJPN108 (std::data(msgs[10000+108])) /* コマンドが受け付けられません. */
 #define MSGJPN109 (std::data(msgs[10000+109])) /* アップロードのために */
-#define MSGJPN110 (std::data(msgs[10000+110])) /* コマンドが受け付けられません. */
-#define MSGJPN111 (std::data(msgs[10000+111])) /* アドレスが取得できません. */
 #define MSGJPN112 (std::data(msgs[10000+112])) /* ファイル %s がオープンできません. */
-#define MSGJPN113 (std::data(msgs[10000+113])) /* アップロードを中止しました. (%lld Sec. %lld B/S). */
-#define MSGJPN114 (std::data(msgs[10000+114])) /* アップロードを中止しました. */
-#define MSGJPN115 (std::data(msgs[10000+115])) /* アップロードは正常終了しました. (%d Sec. %d B/S). */
-#define MSGJPN116 (std::data(msgs[10000+116])) /* アップロードは正常終了しました. */
 #define MSGJPN133 (std::data(msgs[10000+133])) /* GMT%+02d:00 (日本) */
-#define MSGJPN145 (std::data(msgs[10000+145])) /* フォルダを変更できません. */
-#define MSGJPN146 (std::data(msgs[10000+146])) /* フォルダを作成できません. */
 #define MSGJPN147 (std::data(msgs[10000+147])) /* フォルダを削除できません. */
-#define MSGJPN148 (std::data(msgs[10000+148])) /* フォルダを削除できません. */
 #define MSGJPN149 (std::data(msgs[10000+149])) /* ファイルを削除できません. */
-#define MSGJPN150 (std::data(msgs[10000+150])) /* ファイルを削除できません. */
-#define MSGJPN151 (std::data(msgs[10000+151])) /* ファイル名変更ができません. */
-#define MSGJPN177 (std::data(msgs[10000+177])) /* 設定名「%s」はありません. */
-#define MSGJPN178 (std::data(msgs[10000+178])) /* 設定名が指定されていません. */
-#define MSGJPN179 (std::data(msgs[10000+179])) /* ホスト名と設定名の両方が指定されています. */
-#define MSGJPN180 (std::data(msgs[10000+180])) /* オプション「%s」が間違っています. */
-#define MSGJPN182 (std::data(msgs[10000+182])) /* ビューアの起動に失敗しました. (ERROR=%d) */
 #define MSGJPN185 (std::data(msgs[10000+185])) /* フォルダを選択してください */
 #define MSGJPN199 (std::data(msgs[10000+199])) /* ファイル名 */
 #define MSGJPN202 (std::data(msgs[10000+202])) /* ファイル名 */
 #define MSGJPN203 (std::data(msgs[10000+203])) /* ファイル名 */
-#define MSGJPN220 (std::data(msgs[10000+220])) /* ダイアルアップを切断しています. */
-#define MSGJPN221 (std::data(msgs[10000+221])) /* ダイアルアップで接続しています. */
 #define MSGJPN239 (std::data(msgs[10000+239])) /* # このファイルは編集しないでください.\n */
-#define MSGJPN241 (std::data(msgs[10000+241])) /* 送信はタイムアウトで失敗しました. */
-#define MSGJPN242 (std::data(msgs[10000+242])) /* 受信はタイムアウトで失敗しました. */
-#define MSGJPN243 (std::data(msgs[10000+243])) /* 受信はタイムアウトで失敗しました. */
-#define MSGJPN244 (std::data(msgs[10000+244])) /* 固定長の受信が失敗しました */
 #define MSGJPN247 (std::data(msgs[10000+247])) /* 選択%d個（%s） */
 #define MSGJPN248 (std::data(msgs[10000+248])) /* ローカル空 %s */
 #define MSGJPN249 (std::data(msgs[10000+249])) /* 転送待ちファイル%d個 */
@@ -123,16 +58,6 @@ extern std::map<int, std::string> msgs;
 #define MSGJPN279 (std::data(msgs[10000+279])) /* Listenソケットが取得できません */
 #define MSGJPN280 (std::data(msgs[10000+280])) /* Dataソケットが取得できません */
 #define MSGJPN281 (std::data(msgs[10000+281])) /* PASVモードで接続できません */
-#define MSGJPN282 (std::data(msgs[10000+282])) /* INIファイル名が指定されていません */
-#define MSGJPN283 (std::data(msgs[10000+283])) /* INIファイル指定:  */
-#define MSGJPN299 (std::data(msgs[10000+299])) /* コマンドラインにマスターパスワードが指定されていません */
-#define MSGJPN300 (std::data(msgs[10000+300])) /* デフォルトのマスターパスワードが使われます.\r\nマルウェアの攻撃を防ぐため,固有のマスターパスワードを設定することをおすすめします */
-#define MSGJPN301 (std::data(msgs[10000+301])) /* マスターパスワードが設定と一致しません.安全のため設定の保存を行いません. */
-#define MSGJPN302 (std::data(msgs[10000+302])) /* 確認用データが壊れているため,マスターパスワードの正当性を確認できませんでした. */
-#define MSGJPN303 (std::data(msgs[10000+303])) /* マスターパスワードを変更しました */
-#define MSGJPN314 (std::data(msgs[10000+314])) /* 通信は暗号化されていません.\r\n第三者にパスワードおよび内容を傍受される可能性があります. */
-#define MSGJPN315 (std::data(msgs[10000+315])) /* FTP over Explicit SSL/TLS (FTPES)を使用します. */
-#define MSGJPN316 (std::data(msgs[10000+316])) /* FTP over Implicit SSL/TLS (FTPIS)を使用します. */
 #define MSGJPN317 (std::data(msgs[10000+317])) /* SSH FTP (SFTP)を使用します. */
 #define MSGJPN321 (std::data(msgs[10000+321])) /* プロセスの保護に必要な関数を取得できませんでした. */
 #define MSGJPN322 (std::data(msgs[10000+322])) /* デバッガが検出されました. */

--- a/misc.cpp
+++ b/misc.cpp
@@ -729,12 +729,6 @@ void FileTime2TimeString(const FILETIME *Time, char *Buf, int Mode, int InfoExis
 		else
 			Buf[0] = NUL;
 	}
-	else
-	{
-//		if (!strftime((char *)str, 100, "%c",  (const struct tm *)thetime))
-//			SetTaskMsg("strftime が失敗しました!\n");
-	}
-	return;
 }
 
 

--- a/ras.cpp
+++ b/ras.cpp
@@ -50,7 +50,7 @@ static auto GetConnections() {
 static void DisconnectAll(std::vector<RASCONNW> const& connections) {
 	if (empty(connections))
 		return;
-	SetTaskMsg(MSGJPN220);
+	SetTaskMsg(IDS_MSGJPN220);
 	for (auto const& connection : connections) {
 		RasHangUpW(connection.hrasconn);
 		for (RASCONNSTATUSW status{ sizeof(RASCONNSTATUSW) }; RasGetConnectStatusW(connection.hrasconn, &status) != ERROR_INVALID_HANDLE;)
@@ -100,7 +100,7 @@ bool ConnectRas(bool dialup, bool explicitly, bool confirm, std::wstring const& 
 	}
 
 	/* 接続する */
-	SetTaskMsg(MSGJPN221);
+	SetTaskMsg(IDS_MSGJPN221);
 	RASDIALDLG info{ sizeof(RASDIALDLG), GetMainHwnd() };
 	return RasDialDlgW(nullptr, const_cast<LPWSTR>(name.c_str()), nullptr, &info);
 }

--- a/remote.cpp
+++ b/remote.cpp
@@ -556,11 +556,11 @@ SOCKET DoClose(SOCKET Sock)
 //			WSACancelBlockingCall();
 //		}
 		do_closesocket(Sock);
-		DoPrintf("Skt=%zu : Socket closed.", Sock);
+		DoPrintf(L"Skt=%zu : Socket closed.", Sock);
 		Sock = INVALID_SOCKET;
 	}
 	if(Sock != INVALID_SOCKET)
-		DoPrintf("Skt=%zu : Failed to close socket.", Sock);
+		DoPrintf(L"Skt=%zu : Failed to close socket.", Sock);
 
 	return(Sock);
 }

--- a/remote.cpp
+++ b/remote.cpp
@@ -898,12 +898,6 @@ int ReadNchar(SOCKET cSkt, char *Buf, int Size, int *CancelCheckWork)
 }
 
 
-// デバッグコンソールにエラーを表示
-void ReportWSError(const char* Msg, UINT Error) {
-	DoPrintf("[[%s : %s]]", Msg, u8(GetErrorMessage(Error)).c_str());
-}
-
-
 /*----- パスの区切り文字をホストに合わせて変更する ----------------------------
 *
 *	Parameter

--- a/remote.cpp
+++ b/remote.cpp
@@ -550,11 +550,6 @@ SOCKET DoClose(SOCKET Sock)
 {
 	if(Sock != INVALID_SOCKET)
 	{
-//		if(WSAIsBlocking())
-//		{
-//			DoPrintf("Skt=%u : Cancelled blocking call", Sock);
-//			WSACancelBlockingCall();
-//		}
 		do_closesocket(Sock);
 		DoPrintf(L"Skt=%zu : Socket closed.", Sock);
 		Sock = INVALID_SOCKET;
@@ -685,10 +680,6 @@ static int DoDirList(HWND hWnd, SOCKET cSkt, const char* AddOpt, const char* Pat
 	MainTransPkt.hWndTrans = hWnd;
 
 	Sts = DoDownload(cSkt, MainTransPkt, YES, CancelCheckWork);
-
-//#pragma aaa
-//DoPrintf("===== DoDirList Done.");
-
 	return(Sts);
 }
 

--- a/remote.cpp
+++ b/remote.cpp
@@ -791,7 +791,7 @@ static std::tuple<int, std::string> ReadOneLine(SOCKET cSkt, int* CancelCheckWor
 		/* LFまでを受信するために、最初はPEEKで受信 */
 		if ((read = do_recv(cSkt, buffer, size_as<int>(buffer), MSG_PEEK, &TimeOutErr, CancelCheckWork)) <= 0) {
 			if (TimeOutErr == YES) {
-				SetTaskMsg(MSGJPN242);
+				SetTaskMsg(IDS_MSGJPN242);
 				read = -2;
 			} else if (read == SOCKET_ERROR)
 				read = -1;
@@ -855,33 +855,10 @@ int ReadNchar(SOCKET cSkt, char *Buf, int Size, int *CancelCheckWork)
 		Sts = FFFTP_SUCCESS;
 		while(Size > 0)
 		{
-//			FD_ZERO(&ReadFds);
-//			FD_SET(cSkt, &ReadFds);
-//			ToutPtr = NULL;
-//			if(TimeOut != 0)
-//			{
-//				Tout.tv_sec = TimeOut;
-//				Tout.tv_usec = 0;
-//				ToutPtr = &Tout;
-//			}
-//			i = select(0, &ReadFds, NULL, NULL, ToutPtr);
-//			if(i == SOCKET_ERROR)
-//			{
-//				ReportWSError("select", WSAGetLastError());
-//				Sts = FFFTP_FAIL;
-//				break;
-//			}
-//			else if(i == 0)
-//			{
-//				SetTaskMsg(MSGJPN243);
-//				Sts = FFFTP_FAIL;
-//				break;
-//			}
-
 			if((SizeOnce = do_recv(cSkt, Buf, Size, 0, &TimeOutErr, CancelCheckWork)) <= 0)
 			{
 				if(TimeOutErr == YES)
-					SetTaskMsg(MSGJPN243);
+					SetTaskMsg(IDS_MSGJPN243);
 				Sts = FFFTP_FAIL;
 				break;
 			}
@@ -892,7 +869,7 @@ int ReadNchar(SOCKET cSkt, char *Buf, int Size, int *CancelCheckWork)
 	}
 
 	if(Sts == FFFTP_FAIL)
-		SetTaskMsg(MSGJPN244);
+		SetTaskMsg(IDS_MSGJPN244);
 
 	return(Sts);
 }

--- a/socket.cpp
+++ b/socket.cpp
@@ -733,7 +733,7 @@ int SendData(SOCKET s, const char* buf, int len, int flags, int* CancelCheckWork
 		if (BackgrndMessageProc() == YES || *CancelCheckWork == YES)
 			return FFFTP_FAIL;
 		if (endTime && *endTime < std::chrono::steady_clock::now()) {
-			SetTaskMsg(MSGJPN241);
+			SetTaskMsg(IDS_MSGJPN241);
 			*CancelCheckWork = YES;
 			return FFFTP_FAIL;
 		}

--- a/socket.cpp
+++ b/socket.cpp
@@ -834,9 +834,6 @@ int CheckClosedAndReconnect(void)
 {
 	int Error;
 	int Sts;
-
-//SetTaskMsg("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-
 	Sts = FFFTP_SUCCESS;
 	if(AskAsyncDone(AskCmdCtrlSkt(), &Error, FD_CLOSE) == YES)
 	{
@@ -852,9 +849,6 @@ int CheckClosedAndReconnectTrnSkt(SOCKET *Skt, int *CancelCheckWork)
 {
 	int Error;
 	int Sts;
-
-//SetTaskMsg("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-
 	Sts = FFFTP_SUCCESS;
 	if(AskAsyncDone(*Skt, &Error, FD_CLOSE) == YES)
 	{

--- a/socket.cpp
+++ b/socket.cpp
@@ -625,9 +625,6 @@ SOCKET do_accept(SOCKET s, struct sockaddr *addr, int *addrlen)
 	int CancelCheckWork;
 	int Error;
 
-#if DBG_MSG
-	DoPrintf("# Start accept (S=%x)", s);
-#endif
 	CancelCheckWork = NO;
 	Ret2 = INVALID_SOCKET;
 	Error = 0;
@@ -651,10 +648,6 @@ SOCKET do_accept(SOCKET s, struct sockaddr *addr, int *addrlen)
 			Ret2 = accept(s, addr, addrlen);
 			if(Ret2 != INVALID_SOCKET)
 			{
-#if DBG_MSG
-				DoPrintf("## do_sccept (S=%x)", Ret2);
-				DoPrintf("## Async set: FD_CONNECT|FD_CLOSE|FD_ACCEPT|FD_READ|FD_WRITE");
-#endif
 				RegisterAsyncTable(Ret2);
 				// 高速化のためFD_READとFD_WRITEを使用しない
 //				if(WSAAsyncSelect(Ret2, hWndSocket, WM_ASYNC_SOCKET, FD_CONNECT | FD_CLOSE | FD_ACCEPT | FD_READ | FD_WRITE) == SOCKET_ERROR)
@@ -672,10 +665,6 @@ SOCKET do_accept(SOCKET s, struct sockaddr *addr, int *addrlen)
 		}
 		while(Error == WSAEWOULDBLOCK);
 	}
-
-#if DBG_MSG
-	DoPrintf("# Exit accept");
-#endif
 	return(Ret2);
 #else
 	return(accept(s, addr, addrlen));

--- a/taskwin.cpp
+++ b/taskwin.cpp
@@ -96,10 +96,10 @@ void SetTaskMsg(_In_z_ _Printf_format_string_ const char* format, ...) {
 	char buffer[10240 + 3];
 	va_list args;
 	va_start(args, format);
-	int result = vsprintf(buffer, format, args);
+	int result = vsprintf_s(buffer, format, args);
 	va_end(args);
 	if (0 < result)
-		queue.push(u8(buffer));
+		queue.push(u8(buffer, result));
 }
 
 
@@ -115,6 +115,16 @@ void DispTaskMsg() {
 	ExecViewer(data(path), 0);
 }
 
+
+void SetTaskMsg(UINT id, ...) {
+	wchar_t buffer[10240];
+	va_list args;
+	va_start(args, id);
+	int result = vswprintf_s(buffer, GetString(id).c_str(), args);
+	va_end(args);
+	if (0 < result)
+		queue.push({ buffer, static_cast<size_t>(result) });
+}
 
 // デバッグコンソールにメッセージを表示する
 void DoPrintf(_In_z_ _Printf_format_string_ const char* format, ...) {

--- a/taskwin.cpp
+++ b/taskwin.cpp
@@ -120,11 +120,33 @@ void DispTaskMsg() {
 void DoPrintf(_In_z_ _Printf_format_string_ const char* format, ...) {
 	if (DebugConsole != YES)
 		return;
-	char buffer[10240];
+	struct {
+		char prefix[3];
+		char message[10240];
+	} buffer = { { '#', '#', ' ' } };
+	static_assert(std::is_same_v<decltype(buffer.prefix[0]), decltype(buffer.message[0])>);
+	static_assert(sizeof buffer == std::size(buffer.prefix) * sizeof buffer.prefix[0] + std::size(buffer.message) * sizeof buffer.message[0]);
 	va_list args;
 	va_start(args, format);
-	int result = vsprintf(buffer, format, args);
+	int result = vsprintf_s(buffer.message, format, args);
 	va_end(args);
 	if (0 < result)
-		SetTaskMsg("## %s", buffer);
+		queue.push(u8(buffer.prefix, static_cast<size_t>(result) + 3));
+}
+
+void DoPrintf(_In_z_ _Printf_format_string_ const wchar_t* format, ...) {
+	if (DebugConsole != YES)
+		return;
+	struct {
+		wchar_t prefix[3];
+		wchar_t message[10240];
+	} buffer = { { L'#', L'#', L' ' } };
+	static_assert(std::is_same_v<decltype(buffer.prefix[0]), decltype(buffer.message[0])>);
+	static_assert(sizeof buffer == std::size(buffer.prefix) * sizeof buffer.prefix[0] + std::size(buffer.message) * sizeof buffer.message[0]);
+	va_list args;
+	va_start(args, format);
+	int result = vswprintf_s(buffer.message, format, args);
+	va_end(args);
+	if (0 < result)
+		queue.push({ reinterpret_cast<const wchar_t*>(&buffer), static_cast<size_t>(result) + 3 });
 }

--- a/taskwin.cpp
+++ b/taskwin.cpp
@@ -42,8 +42,10 @@ static Concurrency::concurrent_queue<std::wstring> queue;
 
 static VOID CALLBACK Writer(HWND hwnd, UINT, UINT_PTR, DWORD) {
 	std::wstring local;
-	for (std::wstring temp; queue.try_pop(temp);)
+	for (std::wstring temp; queue.try_pop(temp);) {
 		local += temp;
+		local += L"\r\n"sv;
+	}
 	if (empty(local))
 		return;
 	if (auto length = GetWindowTextLengthW(hwnd); RemoveOldLog == YES) {
@@ -96,10 +98,8 @@ void SetTaskMsg(_In_z_ _Printf_format_string_ const char* format, ...) {
 	va_start(args, format);
 	int result = vsprintf(buffer, format, args);
 	va_end(args);
-	if (0 < result) {
-		strcat(buffer, "\r\n");
+	if (0 < result)
 		queue.push(u8(buffer));
-	}
 }
 
 

--- a/taskwin.cpp
+++ b/taskwin.cpp
@@ -150,3 +150,12 @@ void DoPrintf(_In_z_ _Printf_format_string_ const wchar_t* format, ...) {
 	if (0 < result)
 		queue.push({ reinterpret_cast<const wchar_t*>(&buffer), static_cast<size_t>(result) + 3 });
 }
+
+
+// デバッグコンソールにエラーを表示
+void ReportWSError(const wchar_t* functionName) {
+	auto lastError = WSAGetLastError();
+	if (DebugConsole != YES)
+		return;
+	DoPrintf(L"[[%s : %s]]", functionName, GetErrorMessage(lastError).c_str());
+}


### PR DESCRIPTION
今まではメッセージ出力前にUTF-8への変換が必要だった。`SetTaskMsg` と `DoPrintf` をUnicode化する。これでUnicodeメッセージを出力しやすくなる。