### PR TITLE
カラム幅が不正になる問題の対処 (xp)

### DIFF
--- a/common.h
+++ b/common.h
@@ -677,7 +677,6 @@ int MakeListWin();
 void DeleteListWin(void);
 HWND GetLocalHwnd(void);
 HWND GetRemoteHwnd(void);
-void GetListTabWidth(void);
 void SetListViewType(void);
 void GetRemoteDirForWnd(int Mode, int *CancelCheckWork);
 void GetLocalDirForWnd(void);

--- a/filelist.cpp
+++ b/filelist.cpp
@@ -809,29 +809,19 @@ static LRESULT FileListCommonWndProc(HWND hWnd, UINT message, WPARAM wParam, LPA
 			}
 			break;
 
+		case WM_NOTIFY:
+			switch (auto hdr = reinterpret_cast<NMHDR*>(lParam); hdr->code) {
+			case HDN_ITEMCHANGEDW:
+				if (auto header = reinterpret_cast<NMHEADERW*>(lParam); header->pitem && (header->pitem->mask & HDI_WIDTH))
+					(hWnd == hWndListLocal ? LocalTabWidth : RemoteTabWidth)[header->iItem] = header->pitem->cxy;
+				break;
+			}
+			return CallWindowProcW(ProcPtr, hWnd, message, wParam, lParam);
+
 		default :
 			return CallWindowProcW(ProcPtr, hWnd, message, wParam, lParam);
 	}
 	return(0L);
-}
-
-
-/*----- ファイルリストのタブ幅を取得する --------------------------------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		なし
-*----------------------------------------------------------------------------*/
-void GetListTabWidth(void) {
-	int i;
-	i = 0;
-	for (auto& width : LocalTabWidth)
-		width = (int)SendMessageW(hWndListLocal, LVM_GETCOLUMNWIDTH, i++, 0);
-	i = 0;
-	for (auto& width : RemoteTabWidth)
-		width = (int)SendMessageW(hWndListRemote, LVM_GETCOLUMNWIDTH, i++, 0);
 }
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -1271,7 +1271,6 @@ static LRESULT CALLBACK FtpWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARA
 					break;
 
 				case MENU_REGSAVE :
-					GetListTabWidth();
 					SaveRegistry();
 					SaveSettingsToFile();
 					break;
@@ -1754,7 +1753,6 @@ static void ExitProc(HWND hWnd)
 
 	if(SaveExit == YES)
 	{
-		GetListTabWidth();
 		SaveRegistry();
 		// ポータブル版判定
 		if(RegType == REGTYPE_REG)

--- a/main.cpp
+++ b/main.cpp
@@ -150,8 +150,10 @@ int WinWidth = 790;
 int WinHeight = 513;
 int LocalWidth = 389;
 int TaskHeight = 100;
-int LocalTabWidth[4] = { 150, 120, 60, 37 };
-int RemoteTabWidth[6] = { 150, 120, 60, 37, 60, 60 };
+int LocalTabWidthDefault[4] = { 150, 120, 60, 37 };
+int LocalTabWidth[4];
+int RemoteTabWidthDefault[6] = { 150, 120, 60, 37, 60, 60 };
+int RemoteTabWidth[6];
 char UserMailAdrs[USER_MAIL_LEN+1] = { "who@example.com" };
 char ViewerName[VIEWERS][FMAX_PATH+1] = { { "notepad" }, { "" }, { "" } };
 HFONT ListFont = NULL;
@@ -398,8 +400,6 @@ static int InitApp(int cmdShow)
 	int masterpass;
 	// ポータブル版判定
 	int ImportPortable;
-	// 高DPI対応
-	int i;
 
 	sts = FFFTP_FAIL;
 	
@@ -416,10 +416,12 @@ static int InitApp(int cmdShow)
 		WinHeight = CalcPixelY(WinHeight);
 		LocalWidth = CalcPixelX(LocalWidth);
 		TaskHeight = CalcPixelY(TaskHeight);
-		for(i = 0; i < sizeof(LocalTabWidth) / sizeof(int); i++)
-			LocalTabWidth[i] = CalcPixelX(LocalTabWidth[i]);
-		for(i = 0; i < sizeof(RemoteTabWidth) / sizeof(int); i++)
-			RemoteTabWidth[i] = CalcPixelX(RemoteTabWidth[i]);
+		for (auto& width : LocalTabWidthDefault)
+			width = CalcPixelX(width);
+		std::copy(std::begin(LocalTabWidthDefault), std::end(LocalTabWidthDefault), std::begin(LocalTabWidth));
+		for (auto& width : RemoteTabWidthDefault)
+			width = CalcPixelX(width);
+		std::copy(std::begin(RemoteTabWidthDefault), std::end(RemoteTabWidthDefault), std::begin(RemoteTabWidth));
 
 		std::vector<std::wstring_view> args{ __wargv + 1, __wargv + __argc };
 		if (auto it = std::find_if(begin(args), end(args), [](auto const& arg) { return ieq(arg, L"-n"sv) || ieq(arg, L"--ini"sv); }); it != end(args) && ++it != end(args)) {

--- a/registry.cpp
+++ b/registry.cpp
@@ -160,7 +160,9 @@ extern int WinWidth;
 extern int WinHeight;
 extern int LocalWidth;
 extern int TaskHeight;
+extern int LocalTabWidthDefault[4];
 extern int LocalTabWidth[4];
+extern int RemoteTabWidthDefault[6];
 extern int RemoteTabWidth[6];
 extern char UserMailAdrs[USER_MAIL_LEN+1];
 extern char ViewerName[VIEWERS][FMAX_PATH+1];
@@ -934,7 +936,11 @@ int LoadRegistry(void)
 			/* ↓旧バージョンのバグ対策 */
 			TaskHeight = std::max(0, TaskHeight);
 			hKey4->ReadBinaryFromReg("LocalColm", &LocalTabWidth, sizeof(LocalTabWidth));
+			if (std::all_of(std::begin(LocalTabWidth), std::end(LocalTabWidth), [](auto width) { return width <= 0; }))
+				std::copy(std::begin(LocalTabWidthDefault), std::end(LocalTabWidthDefault), std::begin(LocalTabWidth));
 			hKey4->ReadBinaryFromReg("RemoteColm", &RemoteTabWidth, sizeof(RemoteTabWidth));
+			if (std::all_of(std::begin(RemoteTabWidth), std::end(RemoteTabWidth), [](auto width) { return width <= 0; }))
+				std::copy(std::begin(RemoteTabWidthDefault), std::end(RemoteTabWidthDefault), std::begin(RemoteTabWidth));
 			hKey4->ReadIntValueFromReg("SwCmd", &Sizing);
 
 			hKey4->ReadStringFromReg("UserMail", UserMailAdrs, USER_MAIL_LEN+1);


### PR DESCRIPTION
#253 の修正。カラム幅を取得するタイミングを変更すると共に、既に0が保存されていた場合はデフォルト値を復元する。