### PR TITLE
タイトルバーの表示をUnicode化する

### DIFF
--- a/connect.cpp
+++ b/connect.cpp
@@ -41,11 +41,8 @@ static int CheckOneTimePassword(const char *Pass, char *Reply, int Type);
 
 /*===== 外部参照 =====*/
 
-extern char FilterStr[FILTER_EXT_LEN+1];
-extern char TitleHostName[HOST_ADRS_LEN+1];
+extern std::wstring TitleHostName;
 extern int CancelFlg;
-// タイトルバーにユーザー名表示対応
-extern char TitleUserName[USER_NAME_LEN+1];
 
 /* 設定値 */
 std::wstring UserMailAdrs = L"who@example.com"s;
@@ -169,9 +166,7 @@ void ConnectProc(int Type, int Num)
 					break;
 				}
 
-				strcpy(TitleHostName, u8(CurHost.HostName).c_str());
-				// タイトルバーにユーザー名表示対応
-				strcpy(TitleUserName, u8(CurHost.UserName).c_str());
+				TitleHostName = CurHost.HostName;
 				DispWindowTitle();
 				UpdateStatusBar();
 				Sound::Connected.Play();
@@ -280,9 +275,7 @@ void QuickConnectProc() {
 			TrnCtrlSocket = CmdCtrlSocket;
 
 			if (CmdCtrlSocket != INVALID_SOCKET) {
-				strcpy(TitleHostName, u8(CurHost.HostAdrs).c_str());
-				// タイトルバーにユーザー名表示対応
-				strcpy(TitleUserName, u8(CurHost.UserName).c_str());
+				TitleHostName = CurHost.HostAdrs;
 				DispWindowTitle();
 				UpdateStatusBar();
 				Sound::Connected.Play();
@@ -375,9 +368,7 @@ void DirectConnectProc(char *unc, int Kanji, int Kana, int Fkanji, int TrMode)
 
 		if(CmdCtrlSocket != INVALID_SOCKET)
 		{
-			strcpy(TitleHostName, u8(CurHost.HostAdrs).c_str());
-			// タイトルバーにユーザー名表示対応
-			strcpy(TitleUserName, u8(CurHost.UserName).c_str());
+			TitleHostName = CurHost.HostAdrs;
 			DispWindowTitle();
 			UpdateStatusBar();
 			Sound::Connected.Play();
@@ -453,9 +444,7 @@ void HistoryConnectProc(int MenuCmd)
 
 			if(CmdCtrlSocket != INVALID_SOCKET)
 			{
-				strcpy(TitleHostName, u8(CurHost.HostAdrs).c_str());
-				// タイトルバーにユーザー名表示対応
-				strcpy(TitleUserName, u8(CurHost.UserName).c_str());
+				TitleHostName = CurHost.HostAdrs;
 				DispWindowTitle();
 				UpdateStatusBar();
 				Sound::Connected.Play();

--- a/main.cpp
+++ b/main.cpp
@@ -113,11 +113,8 @@ static int ForceIni = NO;
 TRANSPACKET MainTransPkt;		/* ファイル転送用パケット */
 								/* これを使って転送を行うと、ツールバーの転送 */
 								/* 中止ボタンで中止できる */
-
-char TitleHostName[HOST_ADRS_LEN+1];
-char FilterStr[FILTER_EXT_LEN+1] = { "*" };
-char TitleUserName[USER_NAME_LEN+1];
-
+std::wstring TitleHostName;
+std::wstring FilterStr = L"*"s;
 int CancelFlg;
 
 int SuppressRefresh = 0;
@@ -599,12 +596,10 @@ static bool MakeAllWindows(int cmdShow) {
 
 // ウインドウのタイトルを表示する
 void DispWindowTitle() {
-	char text[HOST_ADRS_LEN + FILTER_EXT_LEN + 20];
-	if (AskConnecting() == YES)
-		sprintf(text, "%s (%s) - FFFTP", TitleHostName, FilterStr);
-	else
-		sprintf(text, "FFFTP (%s)", FilterStr);
-	SetWindowTextW(GetMainHwnd(), u8(text).c_str());
+	auto const text = AskConnecting() == YES
+		? strprintf(L"%s (%s) - FFFTP", TitleHostName.c_str(), FilterStr.c_str())
+		: strprintf(L"FFFTP (%s)", FilterStr.c_str());
+	SetWindowTextW(GetMainHwnd(), text.c_str());
 }
 
 


### PR DESCRIPTION
タイトルバーを構成する変数をUTF-8からUnicodeに変更する。
副作用として、フィルターパターンもUnicode化され、フィルター判定毎に文字コード変換を行わなくて済むようになる。