### PR TITLE
fs::pathに不正な文字列が渡される

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1818,7 +1818,7 @@ void DoubleClickProc(int Win, int Mode, int App)
 							}
 							EnableUserOpe();
 
-							AddTempFileList(data(remotePath));
+							AddTempFileList(fs::u8path(remotePath));
 							if(Sts/100 == FTP_COMPLETE) {
 								if (UseDiffViewer) {
 									strcpy(Local, (AskLocalCurDir() / fs::u8path(Tmp)).u8string().c_str());

--- a/main.cpp
+++ b/main.cpp
@@ -1878,7 +1878,7 @@ static void ChangeDir(int Win, const char *Path)
 
 	if((Win == WIN_LOCAL) || (Sync == YES))
 	{
-		if(DoLocalCWD(Path) == FFFTP_SUCCESS)
+		if (DoLocalCWD(fs::u8path(Path)) == FFFTP_SUCCESS)
 			GetLocalDirForWnd();
 	}
 

--- a/toolmenu.cpp
+++ b/toolmenu.cpp
@@ -173,7 +173,7 @@ static LRESULT CALLBACK HistoryEdit(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM 
 		switch (wParam) {
 		case 0x0D:			/* リターンキーが押された */
 			if (isLocal) {
-				DoLocalCWD(u8(GetText(hWnd)).c_str());
+				DoLocalCWD(GetText(hWnd));
 				GetLocalDirForWnd();
 			} else {
 				CancelFlg = NO;


### PR DESCRIPTION
`fs::path`は`char*`から変換可能だが、ANSI（Shift-JIS）文字列を想定している。
しかし、ffftpの`char*`はUTF-8が格納されているため正しく構築できない。
C++言語としては正しくコンストラクターが呼ばれているため警告が出ることはなく、実行時エラーとなる。

ひとまず目grepで正しくないコードを探す。将来的にはUTF-8 `char*`文字列を排除する。