### PR TITLE
設定文字列末尾にNULが残る

### DIFF
--- a/hostman.cpp
+++ b/hostman.cpp
@@ -839,7 +839,7 @@ struct General {
 			TmpHost.HostName = GetText(hDlg, HSET_HOST);
 			TmpHost.HostAdrs = GetText(hDlg, HSET_ADRS);
 			if (auto const p = TmpHost.HostAdrs.find_last_not_of(L' '); p != std::wstring::npos && p + 1 != size(TmpHost.HostAdrs))
-				TmpHost.HostAdrs.resize(p);
+				TmpHost.HostAdrs.erase(p + 1);
 			TmpHost.UserName = GetText(hDlg, HSET_USER);
 			TmpHost.PassWord = GetText(hDlg, HSET_PASS);
 			TmpHost.LocalInitDir = GetText(hDlg, HSET_LOCAL);

--- a/registry.cpp
+++ b/registry.cpp
@@ -41,6 +41,8 @@ class Config {
 	std::optional<std::string> ReadStringCore(std::string_view name) const {
 		if (std::string value; ReadValue(name, value)) {
 			Xor(name, data(value), size_as<DWORD>(value), true);
+			if (auto const pos = value.find_last_not_of('\0'); pos != std::string::npos)
+				value.erase(pos + 1);
 			return std::move(value);
 		}
 		return {};


### PR DESCRIPTION
設定文字列末尾にNULが残っている。暗号化の都合上、消すことができず、復号後に消す必要があったが消されていなかった。
従来は `char*` として暗黙的に消されていた。 `std::wstring` に変更した際、末尾のNULもそのまま保持されるようになってしまった。

これにより #268 のような障害を引き起こしている。