### PR TITLE
ConvertFrom / ConvertTo use std::wstring.

### DIFF
--- a/common.h
+++ b/common.h
@@ -1000,8 +1000,8 @@ public:
 };
 
 std::string ToCRLF(std::string_view source);
-std::string ConvertFrom(std::string_view str, int kanji);
-std::string ConvertTo(std::string_view str, int kanji, int kana);
+std::wstring ConvertFrom(std::string_view str, int kanji);
+std::string ConvertTo(std::wstring_view str, int kanji, int kana);
 
 /*===== option.c =====*/
 

--- a/filelist.cpp
+++ b/filelist.cpp
@@ -2387,9 +2387,9 @@ static std::optional<std::vector<std::variant<FILELIST, std::string>>> GetListLi
 					auto file = ConvertFrom(arg.File, CurHost.CurNameKanjiCode);
 					if (auto last = file.back(); last == '/' || last == '\\')
 						file.resize(file.size() - 1);
-					if (empty(file) || file == "."sv || file == ".."sv)
+					if (empty(file) || file == L"."sv || file == L".."sv)
 						arg.Node = NODE_NONE;
-					strcpy(arg.File, file.c_str());
+					strcpy(arg.File, u8(file).c_str());
 				}
 		}, line);
 	return lines;

--- a/remote.cpp
+++ b/remote.cpp
@@ -735,7 +735,7 @@ int command(SOCKET cSkt, char* Reply, int* CancelCheckWork, _In_z_ _Printf_forma
 		ChangeSepaLocal2Remote(Cmd);
 		SetTaskMsg(">%s", Cmd);
 	}
-	strncpy(Cmd, ConvertTo(Cmd, AskHostNameKanji(), AskHostNameKana()).c_str(), FMAX_PATH * 2);
+	strncpy(Cmd, ConvertTo(u8(Cmd), AskHostNameKanji(), AskHostNameKana()).c_str(), FMAX_PATH * 2);
 	strcat(Cmd, "\x0D\x0A");
 	if (Reply != NULL)
 		strcpy(Reply, "");
@@ -755,7 +755,7 @@ std::tuple<int, std::string> ReadReplyMessage(SOCKET cSkt, int* CancelCheckWork)
 	if (cSkt != INVALID_SOCKET)
 		for (int Lines = 0;; Lines++) {
 			auto [code, line] = ReadOneLine(cSkt, CancelCheckWork);
-			line = ConvertFrom(line, AskHostNameKanji());
+			line = u8(ConvertFrom(line, AskHostNameKanji()));
 			SetTaskMsg("%s", line.c_str());
 
 			// ２行目以降の応答コードは消す


### PR DESCRIPTION
`ConvertFrom`の結果や`ConvertTo`の入力引数はUTF-8文字列となっていたが、`std::wstring`を使うように変更する。