### PR TITLE
エラーメッセージの改善

### DIFF
--- a/connect.cpp
+++ b/connect.cpp
@@ -1285,14 +1285,14 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring con
 				{
 					Flg = 1;
 					if(setsockopt(ContSock, SOL_SOCKET, SO_OOBINLINE, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
-						WSAError(L"setsockopt"sv);
+						WSAError(L"setsockopt(SOL_SOCKET, SO_OOBINLINE)"sv);
 					// データ転送用ソケットのTCP遅延転送が無効されているので念のため
 					if(setsockopt(ContSock, IPPROTO_TCP, TCP_NODELAY, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
-						WSAError(L"setsockopt"sv);
+						WSAError(L"setsockopt(IPPROTO_TCP, TCP_NODELAY)"sv);
 //#pragma aaa
 					Flg = 1;
 					if(setsockopt(ContSock, SOL_SOCKET, SO_KEEPALIVE, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
-						WSAError(L"setsockopt"sv);
+						WSAError(L"setsockopt(SOL_SOCKET, SO_KEEPALIVE)"sv);
 					// 切断対策
 					if(TimeOut > 0)
 					{
@@ -1300,12 +1300,12 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring con
 						KeepAlive.keepalivetime = TimeOut * 1000;
 						KeepAlive.keepaliveinterval = 1000;
 						if(WSAIoctl(ContSock, SIO_KEEPALIVE_VALS, &KeepAlive, sizeof(struct tcp_keepalive), NULL, 0, &dwTmp, NULL, NULL) == SOCKET_ERROR)
-							WSAError(L"WSAIoctl"sv);
+							WSAError(L"WSAIoctl(SIO_KEEPALIVE_VALS)"sv);
 					}
 					LingerOpt.l_onoff = 1;
 					LingerOpt.l_linger = 90;
 					if(setsockopt(ContSock, SOL_SOCKET, SO_LINGER, (LPSTR)&LingerOpt, sizeof(LingerOpt)) == SOCKET_ERROR)
-						WSAError(L"setsockopt"sv);
+						WSAError(L"setsockopt(SOL_SOCKET, SO_LINGER)"sv);
 ///////
 
 
@@ -1870,20 +1870,18 @@ SOCKET GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork) {
 	sockaddr_storage saListen;
 	int salen = sizeof saListen;
 	if (getsockname(ctrl_skt, reinterpret_cast<sockaddr*>(&saListen), &salen) == SOCKET_ERROR) {
-		WSAError(L"getsockname"sv);
+		WSAError(L"getsockname()"sv);
 		return INVALID_SOCKET;
 	}
 	auto listen_skt = do_socket(saListen.ss_family, SOCK_STREAM, IPPROTO_TCP);
-	if (listen_skt == INVALID_SOCKET) {
-		WSAError(L"socket create"sv);
+	if (listen_skt == INVALID_SOCKET)
 		return INVALID_SOCKET;
-	}
 	if (AskHostFireWall() == YES && (FwallType == FWALL_SOCKS4 || FwallType == FWALL_SOCKS5_NOAUTH || FwallType == FWALL_SOCKS5_USER)) {
 		Debug(L"Use SOCKS BIND."sv);
 		// Control接続と同じアドレスに接続する
 		salen = sizeof saListen;
 		if (getpeername(ctrl_skt, reinterpret_cast<sockaddr*>(&saListen), &salen) == SOCKET_ERROR) {
-			WSAError(L"getpeername"sv);
+			WSAError(L"getpeername()"sv);
 			return INVALID_SOCKET;
 		}
 		if (do_connect(listen_skt, reinterpret_cast<const sockaddr*>(&saListen), salen, CancelCheckWork) == SOCKET_ERROR) {
@@ -1906,20 +1904,20 @@ SOCKET GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork) {
 		else
 			reinterpret_cast<sockaddr_in6&>(saListen).sin6_port = 0;
 		if (bind(listen_skt, reinterpret_cast<const sockaddr*>(&saListen), salen) == SOCKET_ERROR) {
-			WSAError(L"bind"sv);
+			WSAError(L"bind()"sv);
 			do_closesocket(listen_skt);
 			SetTaskMsg(IDS_MSGJPN027);
 			return INVALID_SOCKET;
 		}
 		salen = sizeof saListen;
 		if (getsockname(listen_skt, reinterpret_cast<sockaddr*>(&saListen), &salen) == SOCKET_ERROR) {
-			WSAError(L"getsockname"sv);
+			WSAError(L"getsockname()"sv);
 			do_closesocket(listen_skt);
 			SetTaskMsg(IDS_MSGJPN027);
 			return INVALID_SOCKET;
 		}
 		if (do_listen(listen_skt, 1) != 0) {
-			WSAError(L"listen"sv);
+			WSAError(L"listen()"sv);
 			do_closesocket(listen_skt);
 			SetTaskMsg(IDS_MSGJPN027);
 			return INVALID_SOCKET;

--- a/filelist.cpp
+++ b/filelist.cpp
@@ -126,7 +126,7 @@ static inline bool FindFile(fs::path const& fileName, Fn&& fn) {
 		} while (result && FindNextFileW(handle, &data));
 		FindClose(handle);
 	} else
-		Error(L"FindFirstFileW"sv);
+		Error(L"FindFirstFileW()"sv);
 	return result;
 }
 

--- a/getput.cpp
+++ b/getput.cpp
@@ -1128,7 +1128,7 @@ static int DownloadNonPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 					data_socket = do_accept(listen_socket, reinterpret_cast<sockaddr*>(&sa), &salen);
 
 					if(shutdown(listen_socket, 1) != 0)
-						WSAError(L"shutdown listen"sv);
+						WSAError(L"shutdown(listen)"sv);
 					// UPnP対応
 					if(IsUPnPLoaded() == YES)
 					{
@@ -1140,7 +1140,7 @@ static int DownloadNonPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 					if(data_socket == INVALID_SOCKET)
 					{
 						SetErrorMsg(GetString(IDS_MSGJPN280));
-						WSAError(L"accept"sv);
+						WSAError(L"accept()"sv);
 						iRetCode = 500;
 					}
 					else
@@ -1228,7 +1228,7 @@ static int DownloadPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 				// 変数が未初期化のバグ修正
 				Flg = 1;
 				if(setsockopt(data_socket, IPPROTO_TCP, TCP_NODELAY, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
-					WSAError(L"setsockopt"sv);
+					WSAError(L"setsockopt(IPPROTO_TCP, TCP_NODELAY)"sv);
 
 				if(SetDownloadResume(Pkt, Pkt->Mode, Pkt->ExistSize, &CreateMode, CancelCheckWork) == YES)
 				{
@@ -1368,7 +1368,7 @@ static int DownloadFile(TRANSPACKET *Pkt, SOCKET dSkt, int CreateMode, int *Canc
 		}
 
 		if (read == SOCKET_ERROR)
-			WSAError(L"recv"sv);
+			WSAError(L"recv()"sv);
 	} else {
 		SetErrorMsg(strprintf(GetString(IDS_MSGJPN095).c_str(), Pkt->Local.c_str()));
 		SetTaskMsg(IDS_MSGJPN095, Pkt->Local.c_str());
@@ -1376,7 +1376,7 @@ static int DownloadFile(TRANSPACKET *Pkt, SOCKET dSkt, int CreateMode, int *Canc
 	}
 
 	if (shutdown(dSkt, 1) != 0)
-		WSAError(L"shutdown"sv);
+		WSAError(L"shutdown()"sv);
 	LastDataConnectionTime = time(NULL);
 	DoClose(dSkt);
 
@@ -1683,7 +1683,7 @@ static int UploadNonPassive(TRANSPACKET *Pkt)
 				data_socket = do_accept(listen_socket, reinterpret_cast<sockaddr*>(&sa), &salen);
 
 				if(shutdown(listen_socket, 1) != 0)
-					WSAError(L"shutdown listen"sv);
+					WSAError(L"shutdown(listen)"sv);
 				// UPnP対応
 				if(IsUPnPLoaded() == YES)
 				{
@@ -1695,7 +1695,7 @@ static int UploadNonPassive(TRANSPACKET *Pkt)
 				if(data_socket == INVALID_SOCKET)
 				{
 					SetErrorMsg(GetString(IDS_MSGJPN280));
-					WSAError(L"accept"sv);
+					WSAError(L"accept()"sv);
 					iRetCode = 500;
 				}
 				else
@@ -1769,7 +1769,7 @@ static int UploadPassive(TRANSPACKET *Pkt)
 				// 変数が未初期化のバグ修正
 				Flg = 1;
 				if(setsockopt(data_socket, IPPROTO_TCP, TCP_NODELAY, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
-					WSAError(L"setsockopt"sv);
+					WSAError(L"setsockopt(IPPROTO_TCP, TCP_NODELAY)"sv);
 
 				SetUploadResume(Pkt, Pkt->Mode, Pkt->ExistSize, &Resume);
 				std::wstring cmd;
@@ -1912,7 +1912,7 @@ static int UploadFile(TRANSPACKET *Pkt, SOCKET dSkt) {
 
 	LastDataConnectionTime = time(NULL);
 	if (shutdown(dSkt, 1) != 0)
-		WSAError(L"shutdown"sv);
+		WSAError(L"shutdown()"sv);
 
 	auto [code, text] = ReadReplyMessage(Pkt->ctrl_skt, &Canceled[Pkt->ThreadCount]);
 	if (code / 100 >= FTP_RETRY)

--- a/socket.cpp
+++ b/socket.cpp
@@ -554,7 +554,7 @@ int GetAsyncTableDataMapPort(SOCKET s, int* Port) {
 SOCKET do_socket(int af, int type, int protocol) {
 	auto s = socket(af, type, protocol);
 	if (s == INVALID_SOCKET) {
-		Debug(L"socket: socket failed: 0x{:08X}."sv, WSAGetLastError());
+		WSAError(L"socket()"sv);
 		return INVALID_SOCKET;
 	}
 	RegisterAsyncTable(s);

--- a/taskwin.cpp
+++ b/taskwin.cpp
@@ -129,5 +129,5 @@ void detail::Debug(std::wstring_view format, std::wformat_args args) {
 
 void Error(std::wstring_view functionName, int lastError) {
 	if (DebugConsole == YES)
-		Debug(L"{}() failed: {}"sv, functionName, GetErrorMessage(lastError));
+		Debug(L"{} failed(0x{:08X}): {}"sv, functionName, unsigned(lastError), GetErrorMessage(lastError));
 }


### PR DESCRIPTION
`Error`関数は生の関数名を受け取っていたが、引数も渡せるようにしておく。