### PR TITLE
Socket周りのリファクタリング

### DIFF
--- a/common.h
+++ b/common.h
@@ -518,7 +518,7 @@ struct HISTORYDATA : Host {
 
 
 struct TRANSPACKET {
-	SOCKET ctrl_skt = INVALID_SOCKET;	/* Socket */
+	std::shared_ptr<SocketContext> ctrl_skt;	/* Socket */
 	std::wstring Command;				/* STOR/RETR/MKD */
 	std::wstring Remote;				/* ホスト側のファイル名（フルパス） */
 										/* VMSの時は ddd[xxx.yyy]/yyy/zzz のように */

--- a/common.h
+++ b/common.h
@@ -431,6 +431,7 @@ struct SocketContext {
 	constexpr bool operator==(SocketContext const& other) { return handle == other.handle; }
 	static std::shared_ptr<SocketContext> Create(int af, int type, int protocol);
 	std::shared_ptr<SocketContext> Accept(_Out_writes_bytes_opt_(*addrlen) struct sockaddr* addr, _Inout_opt_ int* addrlen);
+	int Close();
 };
 
 
@@ -1085,7 +1086,6 @@ BOOL IsSSLAttached(SOCKET s);
 int MakeSocketWin();
 void DeleteSocketWin(void);
 int do_connect(SOCKET s, const struct sockaddr *name, int namelen, int *CancelCheckWork);
-int do_closesocket(SOCKET s);
 int do_listen(SOCKET s,	int backlog);
 int do_recv(SOCKET s, char *buf, int len, int flags, int *TimeOut, int *CancelCheckWork);
 int SendData(SOCKET s, const char* buf, int len, int flags, int* CancelCheckWork);

--- a/common.h
+++ b/common.h
@@ -935,7 +935,7 @@ int AskTransferNow(void);
 int AskTransferFileNum(void);
 void GoForwardTransWindow(void);
 void InitTransCurDir(void);
-int DoDownload(SOCKET cSkt, TRANSPACKET& item, int DirList, int *CancelCheckWork);
+int DoDownload(std::shared_ptr<SocketContext> cSkt, TRANSPACKET& item, int DirList, int *CancelCheckWork);
 int CheckPathViolation(TRANSPACKET const& item);
 // タスクバー進捗表示
 LONGLONG AskTransferSizeLeft(void);

--- a/common.h
+++ b/common.h
@@ -814,9 +814,9 @@ int AskRealHostType(void);
 int SetOSS(int wkOss);
 int AskOSS(void);
 #endif
-std::optional<sockaddr_storage> SocksReceiveReply(SOCKET s, int* CancelCheckWork);
+std::optional<sockaddr_storage> SocksReceiveReply(std::shared_ptr<SocketContext> s, int* CancelCheckWork);
 std::shared_ptr<SocketContext> connectsock(std::wstring&& host, int port, UINT prefixId, int *CancelCheckWork);
-std::shared_ptr<SocketContext> GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork);
+std::shared_ptr<SocketContext> GetFTPListenSocket(std::shared_ptr<SocketContext> ctrl_skt, int *CancelCheckWork);
 int AskTryingConnect(void);
 int AskUseNoEncryption(void);
 int AskUseFTPES(void);

--- a/common.h
+++ b/common.h
@@ -423,9 +423,12 @@ constexpr FileType AllFileTyes[]{ FileType::All, FileType::Executable, FileType:
 
 
 struct SocketContext {
-	SOCKET handle;
-	static std::shared_ptr<SocketContext> Create(int af, int type, int protocol);
+	SOCKET const handle;
+	SocketContext(SOCKET s) : handle{ s } {}
+	SocketContext(SocketContext const&) = delete;
 	constexpr bool operator==(SocketContext const& other) { return handle == other.handle; }
+	static std::shared_ptr<SocketContext> Create(int af, int type, int protocol);
+	std::shared_ptr<SocketContext> Accept(_Out_writes_bytes_opt_(*addrlen) struct sockaddr* addr, _Inout_opt_ int* addrlen);
 };
 
 
@@ -1088,7 +1091,6 @@ int GetAsyncTableDataMapPort(SOCKET s, int* Port);
 int do_connect(SOCKET s, const struct sockaddr *name, int namelen, int *CancelCheckWork);
 int do_closesocket(SOCKET s);
 int do_listen(SOCKET s,	int backlog);
-std::shared_ptr<SocketContext> do_accept(SOCKET s, struct sockaddr *addr, int *addrlen);
 int do_recv(SOCKET s, char *buf, int len, int flags, int *TimeOut, int *CancelCheckWork);
 int SendData(SOCKET s, const char* buf, int len, int flags, int* CancelCheckWork);
 // 同時接続対応

--- a/common.h
+++ b/common.h
@@ -456,13 +456,17 @@ struct SocketContext {
 	static std::shared_ptr<SocketContext> Create(int af, int type, int protocol);
 	std::shared_ptr<SocketContext> Accept(_Out_writes_bytes_opt_(*addrlen) struct sockaddr* addr, _Inout_opt_ int* addrlen);
 	int Close();
-	BOOL AttachSSL(std::shared_ptr<SocketContext> parent, BOOL* pbAborted, std::wstring_view ServerName);
+	BOOL AttachSSL(SocketContext* parent, BOOL* pbAborted, std::wstring_view ServerName);
 	constexpr bool IsSSLAttached() {
 		return sslContext.has_value();
 	}
 	bool GetEvent(int mask);
 	int Connect(const sockaddr* name, int namelen, int* CancelCheckWork);
 	int Listen(int backlog);
+	int RecvInternal(char* buf, int len, int flags);
+	int Recv(char* buf, int len, int flags, int* TimeOutErr, int* CancelCheckWork);
+	void RemoveReceivedData();
+	int Send(const char* buf, int len, int flags, int* CancelCheckWork);
 };
 
 
@@ -1114,10 +1118,6 @@ void ShowCertificate();
 bool IsSecureConnection();
 int MakeSocketWin();
 void DeleteSocketWin(void);
-int do_recv(std::shared_ptr<SocketContext> s, char *buf, int len, int flags, int *TimeOut, int *CancelCheckWork);
-int SendData(std::shared_ptr<SocketContext> s, const char* buf, int len, int flags, int* CancelCheckWork);
-// 同時接続対応
-void RemoveReceivedData(std::shared_ptr<SocketContext> s);
 // UPnP対応
 int LoadUPnP();
 void FreeUPnP();

--- a/common.h
+++ b/common.h
@@ -462,6 +462,7 @@ struct SocketContext {
 	}
 	bool GetEvent(int mask);
 	int Connect(const sockaddr* name, int namelen, int* CancelCheckWork);
+	int Listen(int backlog);
 };
 
 
@@ -1113,7 +1114,6 @@ void ShowCertificate();
 bool IsSecureConnection();
 int MakeSocketWin();
 void DeleteSocketWin(void);
-int do_listen(SOCKET s,	int backlog);
 int do_recv(std::shared_ptr<SocketContext> s, char *buf, int len, int flags, int *TimeOut, int *CancelCheckWork);
 int SendData(std::shared_ptr<SocketContext> s, const char* buf, int len, int flags, int* CancelCheckWork);
 // 同時接続対応

--- a/common.h
+++ b/common.h
@@ -422,6 +422,13 @@ constexpr FileType AllFileTyes[]{ FileType::All, FileType::Executable, FileType:
 #define NTYPE_IPV6			2		/* TCP/IPv6 */
 
 
+struct SocketContext {
+	SOCKET handle;
+	static std::shared_ptr<SocketContext> Create(int af, int type, int protocol);
+	constexpr bool operator==(SocketContext const& other) { return handle == other.handle; }
+};
+
+
 struct HostExeptPassword {
 	static inline auto DefaultChmod = L"SITE CHMOD"s;	/* 属性変更コマンド */
 	static inline auto DefaultLsOption = L"-alL"s;		/* NLSTに付けるもの */
@@ -790,11 +797,9 @@ int AskHostFireWall(void);
 int AskNoFullPathMode(void);
 void SaveCurrentSetToHost(void);
 int ReConnectCmdSkt(void);
-// int ReConnectTrnSkt(void);
-// 同時接続対応
-int ReConnectTrnSkt(SOCKET *Skt, int *CancelCheckWork);
+int ReConnectTrnSkt(std::shared_ptr<SocketContext>& Skt, int *CancelCheckWork);
 SOCKET AskCmdCtrlSkt(void);
-SOCKET AskTrnCtrlSkt(void);
+std::shared_ptr<SocketContext> AskTrnCtrlSkt();
 void SktShareProh(void);
 int AskShareProh(void);
 void DisconnectProc(void);
@@ -806,8 +811,8 @@ int SetOSS(int wkOss);
 int AskOSS(void);
 #endif
 std::optional<sockaddr_storage> SocksReceiveReply(SOCKET s, int* CancelCheckWork);
-SOCKET connectsock(std::wstring&& host, int port, UINT prefixId, int *CancelCheckWork);
-SOCKET GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork);
+std::shared_ptr<SocketContext> connectsock(std::wstring&& host, int port, UINT prefixId, int *CancelCheckWork);
+std::shared_ptr<SocketContext> GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork);
 int AskTryingConnect(void);
 int AskUseNoEncryption(void);
 int AskUseFTPES(void);
@@ -892,7 +897,7 @@ int DoSIZE(SOCKET cSkt, std::wstring const& Path, LONGLONG *Size, int *CancelChe
 int DoMDTM(SOCKET cSkt, std::wstring const& Path, FILETIME *Time, int *CancelCheckWork);
 int DoMFMT(SOCKET cSkt, std::wstring const&, FILETIME *Time, int *CancelCheckWork);
 int DoQUOTE(SOCKET cSkt, std::wstring_view CmdStr, int* CancelCheckWork);
-SOCKET DoClose(SOCKET Sock);
+void DoClose(SOCKET Sock);
 // 同時接続対応
 //int DoQUIT(SOCKET ctrl_skt);
 int DoQUIT(SOCKET ctrl_skt, int *CancelCheckWork);
@@ -1080,11 +1085,10 @@ void SetAsyncTableData(SOCKET s, std::variant<sockaddr_storage, std::tuple<std::
 void SetAsyncTableDataMapPort(SOCKET s, int Port);
 int GetAsyncTableData(SOCKET s, std::variant<sockaddr_storage, std::tuple<std::wstring, int>>& target);
 int GetAsyncTableDataMapPort(SOCKET s, int* Port);
-SOCKET do_socket(int af, int type, int protocol);
 int do_connect(SOCKET s, const struct sockaddr *name, int namelen, int *CancelCheckWork);
 int do_closesocket(SOCKET s);
 int do_listen(SOCKET s,	int backlog);
-SOCKET do_accept(SOCKET s, struct sockaddr *addr, int *addrlen);
+std::shared_ptr<SocketContext> do_accept(SOCKET s, struct sockaddr *addr, int *addrlen);
 int do_recv(SOCKET s, char *buf, int len, int flags, int *TimeOut, int *CancelCheckWork);
 int SendData(SOCKET s, const char* buf, int len, int flags, int* CancelCheckWork);
 // 同時接続対応
@@ -1097,7 +1101,7 @@ std::optional<std::wstring> AddPortMapping(std::wstring const& internalAddress, 
 bool RemovePortMapping(int port);
 int CheckClosedAndReconnect(void);
 // 同時接続対応
-int CheckClosedAndReconnectTrnSkt(SOCKET *Skt, int *CancelCheckWork);
+int CheckClosedAndReconnectTrnSkt(std::shared_ptr<SocketContext>& Skt, int *CancelCheckWork);
 
 
 extern int DebugConsole;

--- a/common.h
+++ b/common.h
@@ -446,6 +446,7 @@ struct SocketContext {
 	SecPkgContext_StreamSizes sslStreamSizes = {};
 	std::vector<char> readRaw;
 	std::vector<char> readPlain;
+	bool sslNeedRenegotiate = false;
 	SECURITY_STATUS sslReadStatus = SEC_E_OK;
 
 	inline SocketContext(SOCKET s, std::wstring originalTarget, std::wstring punyTarget);

--- a/common.h
+++ b/common.h
@@ -901,21 +901,21 @@ int DoSIZE(std::shared_ptr<SocketContext> cSkt, std::wstring const& Path, LONGLO
 int DoMDTM(std::shared_ptr<SocketContext> cSkt, std::wstring const& Path, FILETIME *Time, int *CancelCheckWork);
 int DoMFMT(std::shared_ptr<SocketContext> cSkt, std::wstring const&, FILETIME *Time, int *CancelCheckWork);
 int DoQUOTE(std::shared_ptr<SocketContext> cSkt, std::wstring_view CmdStr, int* CancelCheckWork);
-void DoClose(SOCKET Sock);
+void DoClose(std::shared_ptr<SocketContext> Sock);
 int DoQUIT(std::shared_ptr<SocketContext> ctrl_skt, int *CancelCheckWork);
 int DoDirList(std::wstring_view AddOpt, int Num, int* CancelCheckWork);
 #if defined(HAVE_TANDEM)
 void SwitchOSSProc(void);
 #endif
 namespace detail {
-	std::tuple<int, std::wstring> command(SOCKET cSkt, int* CancelCheckWork, std::wstring&& cmd);
+	std::tuple<int, std::wstring> command(std::shared_ptr<SocketContext> cSkt, int* CancelCheckWork, std::wstring&& cmd);
 }
 template<class... Args>
-static inline std::tuple<int, std::wstring> Command(SOCKET socket, int* CancelCheckWork, std::wstring_view format, const Args&... args) {
-	return socket == INVALID_SOCKET ? std::tuple{ 429, L""s } : detail::command(socket, CancelCheckWork, std::format(format, args...));
+static inline std::tuple<int, std::wstring> Command(std::shared_ptr<SocketContext> socket, int* CancelCheckWork, std::wstring_view format, const Args&... args) {
+	return !socket ? std::tuple{ 429, L""s } : detail::command(socket, CancelCheckWork, std::format(format, args...));
 }
-std::tuple<int, std::wstring> ReadReplyMessage(SOCKET cSkt, int *CancelCheckWork);
-int ReadNchar(SOCKET cSkt, char *Buf, int Size, int *CancelCheckWork);
+std::tuple<int, std::wstring> ReadReplyMessage(std::shared_ptr<SocketContext> cSkt, int *CancelCheckWork);
+int ReadNchar(std::shared_ptr<SocketContext> cSkt, char *Buf, int Size, int *CancelCheckWork);
 
 /*===== getput.c =====*/
 

--- a/common.h
+++ b/common.h
@@ -897,14 +897,12 @@ int DoRMD(std::wstring const& path);
 int DoDELE(std::wstring const& path);
 int DoRENAME(std::wstring const& from, std::wstring const& to);
 int DoCHMOD(std::wstring const& path, std::wstring const& mode);
-int DoSIZE(SOCKET cSkt, std::wstring const& Path, LONGLONG *Size, int *CancelCheckWork);
-int DoMDTM(SOCKET cSkt, std::wstring const& Path, FILETIME *Time, int *CancelCheckWork);
-int DoMFMT(SOCKET cSkt, std::wstring const&, FILETIME *Time, int *CancelCheckWork);
-int DoQUOTE(SOCKET cSkt, std::wstring_view CmdStr, int* CancelCheckWork);
+int DoSIZE(std::shared_ptr<SocketContext> cSkt, std::wstring const& Path, LONGLONG *Size, int *CancelCheckWork);
+int DoMDTM(std::shared_ptr<SocketContext> cSkt, std::wstring const& Path, FILETIME *Time, int *CancelCheckWork);
+int DoMFMT(std::shared_ptr<SocketContext> cSkt, std::wstring const&, FILETIME *Time, int *CancelCheckWork);
+int DoQUOTE(std::shared_ptr<SocketContext> cSkt, std::wstring_view CmdStr, int* CancelCheckWork);
 void DoClose(SOCKET Sock);
-// 同時接続対応
-//int DoQUIT(SOCKET ctrl_skt);
-int DoQUIT(SOCKET ctrl_skt, int *CancelCheckWork);
+int DoQUIT(std::shared_ptr<SocketContext> ctrl_skt, int *CancelCheckWork);
 int DoDirList(std::wstring_view AddOpt, int Num, int* CancelCheckWork);
 #if defined(HAVE_TANDEM)
 void SwitchOSSProc(void);

--- a/common.h
+++ b/common.h
@@ -425,6 +425,7 @@ constexpr FileType AllFileTyes[]{ FileType::All, FileType::Executable, FileType:
 struct SocketContext {
 	SOCKET const handle;
 	int mapPort = 0;
+	std::variant<sockaddr_storage, std::tuple<std::wstring, int>> target;
 	SocketContext(SOCKET s) : handle{ s } {}
 	SocketContext(SocketContext const&) = delete;
 	constexpr bool operator==(SocketContext const& other) { return handle == other.handle; }
@@ -1083,8 +1084,6 @@ bool IsSecureConnection();
 BOOL IsSSLAttached(SOCKET s);
 int MakeSocketWin();
 void DeleteSocketWin(void);
-void SetAsyncTableData(SOCKET s, std::variant<sockaddr_storage, std::tuple<std::wstring, int>> const& target);
-int GetAsyncTableData(SOCKET s, std::variant<sockaddr_storage, std::tuple<std::wstring, int>>& target);
 int do_connect(SOCKET s, const struct sockaddr *name, int namelen, int *CancelCheckWork);
 int do_closesocket(SOCKET s);
 int do_listen(SOCKET s,	int backlog);

--- a/common.h
+++ b/common.h
@@ -801,7 +801,7 @@ int AskNoFullPathMode(void);
 void SaveCurrentSetToHost(void);
 int ReConnectCmdSkt(void);
 int ReConnectTrnSkt(std::shared_ptr<SocketContext>& Skt, int *CancelCheckWork);
-SOCKET AskCmdCtrlSkt(void);
+std::shared_ptr<SocketContext> AskCmdCtrlSkt();
 std::shared_ptr<SocketContext> AskTrnCtrlSkt();
 void SktShareProh(void);
 int AskShareProh(void);

--- a/common.h
+++ b/common.h
@@ -868,7 +868,7 @@ void SomeCmdProc(void);
 void CalcFileSizeProc(void);
 void DispCWDerror(HWND hWnd);
 void CopyURLtoClipBoard(void);
-int ProcForNonFullpath(SOCKET cSkt, std::wstring& Path, std::wstring& CurDir, HWND hWnd, int* CancelCheckWork);
+int ProcForNonFullpath(std::shared_ptr<SocketContext> cSkt, std::wstring& Path, std::wstring& CurDir, HWND hWnd, int* CancelCheckWork);
 #if defined(HAVE_OPENVMS)
 std::wstring ReformVMSDirName(std::wstring&& dirName);
 #endif

--- a/common.h
+++ b/common.h
@@ -445,6 +445,8 @@ struct SslContext {
 
 struct SocketContext {
 	SOCKET const handle;
+	int event = 0;
+	int error = 0;
 	int mapPort = 0;
 	std::variant<sockaddr_storage, std::tuple<std::wstring, int>> target;
 	std::optional<SslContext> sslContext;
@@ -458,6 +460,8 @@ struct SocketContext {
 	constexpr bool IsSSLAttached() {
 		return sslContext.has_value();
 	}
+	bool GetEvent(int mask);
+	int Connect(const sockaddr* name, int namelen, int* CancelCheckWork);
 };
 
 
@@ -1109,7 +1113,6 @@ void ShowCertificate();
 bool IsSecureConnection();
 int MakeSocketWin();
 void DeleteSocketWin(void);
-int do_connect(SOCKET s, const struct sockaddr *name, int namelen, int *CancelCheckWork);
 int do_listen(SOCKET s,	int backlog);
 int do_recv(std::shared_ptr<SocketContext> s, char *buf, int len, int flags, int *TimeOut, int *CancelCheckWork);
 int SendData(std::shared_ptr<SocketContext> s, const char* buf, int len, int flags, int* CancelCheckWork);

--- a/common.h
+++ b/common.h
@@ -424,6 +424,7 @@ constexpr FileType AllFileTyes[]{ FileType::All, FileType::Executable, FileType:
 
 struct SocketContext {
 	SOCKET const handle;
+	int mapPort = 0;
 	SocketContext(SOCKET s) : handle{ s } {}
 	SocketContext(SocketContext const&) = delete;
 	constexpr bool operator==(SocketContext const& other) { return handle == other.handle; }
@@ -1085,9 +1086,7 @@ BOOL IsSSLAttached(SOCKET s);
 int MakeSocketWin();
 void DeleteSocketWin(void);
 void SetAsyncTableData(SOCKET s, std::variant<sockaddr_storage, std::tuple<std::wstring, int>> const& target);
-void SetAsyncTableDataMapPort(SOCKET s, int Port);
 int GetAsyncTableData(SOCKET s, std::variant<sockaddr_storage, std::tuple<std::wstring, int>>& target);
-int GetAsyncTableDataMapPort(SOCKET s, int* Port);
 int do_connect(SOCKET s, const struct sockaddr *name, int namelen, int *CancelCheckWork);
 int do_closesocket(SOCKET s);
 int do_listen(SOCKET s,	int backlog);

--- a/common.h
+++ b/common.h
@@ -426,7 +426,7 @@ struct SocketContext {
 	SOCKET const handle;
 	int mapPort = 0;
 	std::variant<sockaddr_storage, std::tuple<std::wstring, int>> target;
-	SocketContext(SOCKET s) : handle{ s } {}
+	SocketContext(SOCKET s);
 	SocketContext(SocketContext const&) = delete;
 	constexpr bool operator==(SocketContext const& other) { return handle == other.handle; }
 	static std::shared_ptr<SocketContext> Create(int af, int type, int protocol);

--- a/connect.cpp
+++ b/connect.cpp
@@ -1175,8 +1175,7 @@ static std::shared_ptr<SocketContext> DoConnectCrypt(int CryptMode, HOSTDATA* Ho
 #endif
 				if(CryptMode == CRYPT_FTPIS)
 				{
-					if(AttachSSL(ContSock->handle, INVALID_SOCKET, CancelCheckWork, Host))
-					{
+					if (ContSock->AttachSSL({}, CancelCheckWork, Host)) {
 						while((Sts = std::get<0>(ReadReplyMessage(ContSock, CancelCheckWork)) / 100) == FTP_PRELIM)
 							;
 					}
@@ -1272,7 +1271,7 @@ static std::shared_ptr<SocketContext> DoConnectCrypt(int CryptMode, HOSTDATA* Ho
 								if (CryptMode == CRYPT_FTPES) {
 									if ((Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"AUTH TLS"sv))) != 234 && (Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"AUTH SSL"sv))) != 234)
 										Sts = FTP_ERROR;
-									else if (!AttachSSL(ContSock->handle, INVALID_SOCKET, CancelCheckWork, Host))
+									else if (!ContSock->AttachSSL({}, CancelCheckWork, Host))
 										Sts = FTP_ERROR;
 									else if ((Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"PBSZ 0"sv))) != 200)
 										Sts = FTP_ERROR;
@@ -1521,7 +1520,7 @@ enum class SocksCommand : uint8_t {
 
 
 static bool SocksSend(std::shared_ptr<SocketContext> s, std::vector<uint8_t> const& buffer, int* CancelCheckWork) {
-	if (SendData(s->handle, reinterpret_cast<const char*>(data(buffer)), size_as<int>(buffer), 0, CancelCheckWork) != FFFTP_SUCCESS) {
+	if (SendData(s, reinterpret_cast<const char*>(data(buffer)), size_as<int>(buffer), 0, CancelCheckWork) != FFFTP_SUCCESS) {
 		Notice(IDS_MSGJPN033, *reinterpret_cast<const unsigned short*>(&buffer[0]));
 		return false;
 	}

--- a/connect.cpp
+++ b/connect.cpp
@@ -1751,7 +1751,7 @@ std::shared_ptr<SocketContext> connectsock(std::wstring&& host, int port, UINT p
 		return {};
 	}
 	s->target = target;
-	if (do_connect(s->handle, reinterpret_cast<const sockaddr*>(&saConnect), sizeof saConnect, CancelCheckWork) == SOCKET_ERROR) {
+	if (s->Connect(reinterpret_cast<const sockaddr*>(&saConnect), sizeof saConnect, CancelCheckWork) == SOCKET_ERROR) {
 		Notice(IDS_MSGJPN026);
 		DoClose(s);
 		return {};
@@ -1790,7 +1790,7 @@ std::shared_ptr<SocketContext> GetFTPListenSocket(std::shared_ptr<SocketContext>
 			WSAError(L"getpeername()"sv);
 			return {};
 		}
-		if (do_connect(listen_skt->handle, reinterpret_cast<const sockaddr*>(&saListen), salen, CancelCheckWork) == SOCKET_ERROR) {
+		if (listen_skt->Connect(reinterpret_cast<const sockaddr*>(&saListen), salen, CancelCheckWork) == SOCKET_ERROR) {
 			return {};
 		}
 		if (auto result = SocksRequest(listen_skt, SocksCommand::Bind, ctrl_skt->target, CancelCheckWork)) {

--- a/connect.cpp
+++ b/connect.cpp
@@ -1820,7 +1820,7 @@ std::shared_ptr<SocketContext> GetFTPListenSocket(std::shared_ptr<SocketContext>
 			Notice(IDS_MSGJPN027);
 			return {};
 		}
-		if (do_listen(listen_skt->handle, 1) != 0) {
+		if (listen_skt->Listen(1) != 0) {
 			WSAError(L"listen()"sv);
 			listen_skt->Close();
 			Notice(IDS_MSGJPN027);

--- a/connect.cpp
+++ b/connect.cpp
@@ -1836,7 +1836,7 @@ std::shared_ptr<SocketContext> GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCh
 			if (auto const ExtAdrs = AddPortMapping(AddressToString(saListen), port))
 				if (auto ai = getaddrinfo(*ExtAdrs, port)) {
 					memcpy(&saListen, ai->ai_addr, ai->ai_addrlen);
-					SetAsyncTableDataMapPort(listen_skt->handle, port);
+					listen_skt->mapPort = port;
 				}
 		}
 	}
@@ -1853,8 +1853,7 @@ std::shared_ptr<SocketContext> GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCh
 	if (status / 100 != FTP_COMPLETE) {
 		Notice(IDS_MSGJPN031, saListen.ss_family == AF_INET ? L"PORT"sv : L"EPRT"sv);
 		if (IsUPnPLoaded() == YES)
-			if (int port; GetAsyncTableDataMapPort(listen_skt->handle, &port) == YES)
-				RemovePortMapping(port);
+			RemovePortMapping(listen_skt->mapPort);
 		do_closesocket(listen_skt->handle);
 		return {};
 	}

--- a/connect.cpp
+++ b/connect.cpp
@@ -1751,7 +1751,7 @@ std::shared_ptr<SocketContext> connectsock(std::wstring&& host, int port, UINT p
 		Notice(IDS_MSGJPN027);
 		return {};
 	}
-	SetAsyncTableData(s->handle, target);
+	s->target = target;
 	if (do_connect(s->handle, reinterpret_cast<const sockaddr*>(&saConnect), sizeof saConnect, CancelCheckWork) == SOCKET_ERROR) {
 		Notice(IDS_MSGJPN026);
 		DoClose(s);
@@ -1794,9 +1794,7 @@ std::shared_ptr<SocketContext> GetFTPListenSocket(std::shared_ptr<SocketContext>
 		if (do_connect(listen_skt->handle, reinterpret_cast<const sockaddr*>(&saListen), salen, CancelCheckWork) == SOCKET_ERROR) {
 			return {};
 		}
-		std::variant<sockaddr_storage, std::tuple<std::wstring, int>> target;
-		GetAsyncTableData(ctrl_skt->handle, target);
-		if (auto result = SocksRequest(listen_skt, SocksCommand::Bind, target, CancelCheckWork)) {
+		if (auto result = SocksRequest(listen_skt, SocksCommand::Bind, ctrl_skt->target, CancelCheckWork)) {
 			saListen = *result;
 		} else {
 			Notice(IDS_MSGJPN023);

--- a/connect.cpp
+++ b/connect.cpp
@@ -1175,7 +1175,7 @@ static std::shared_ptr<SocketContext> DoConnectCrypt(int CryptMode, HOSTDATA* Ho
 #endif
 				if(CryptMode == CRYPT_FTPIS)
 				{
-					if (ContSock->AttachSSL({}, CancelCheckWork, Host)) {
+					if (ContSock->AttachSSL(nullptr, CancelCheckWork, Host)) {
 						while((Sts = std::get<0>(ReadReplyMessage(ContSock, CancelCheckWork)) / 100) == FTP_PRELIM)
 							;
 					}
@@ -1271,7 +1271,7 @@ static std::shared_ptr<SocketContext> DoConnectCrypt(int CryptMode, HOSTDATA* Ho
 								if (CryptMode == CRYPT_FTPES) {
 									if ((Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"AUTH TLS"sv))) != 234 && (Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"AUTH SSL"sv))) != 234)
 										Sts = FTP_ERROR;
-									else if (!ContSock->AttachSSL({}, CancelCheckWork, Host))
+									else if (!ContSock->AttachSSL(nullptr, CancelCheckWork, Host))
 										Sts = FTP_ERROR;
 									else if ((Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"PBSZ 0"sv))) != 200)
 										Sts = FTP_ERROR;
@@ -1520,7 +1520,8 @@ enum class SocksCommand : uint8_t {
 
 
 static bool SocksSend(std::shared_ptr<SocketContext> s, std::vector<uint8_t> const& buffer, int* CancelCheckWork) {
-	if (SendData(s, reinterpret_cast<const char*>(data(buffer)), size_as<int>(buffer), 0, CancelCheckWork) != FFFTP_SUCCESS) {
+	assert(s);
+	if (s->Send(reinterpret_cast<const char*>(data(buffer)), size_as<int>(buffer), 0, CancelCheckWork) != FFFTP_SUCCESS) {
 		Notice(IDS_MSGJPN033, *reinterpret_cast<const unsigned short*>(&buffer[0]));
 		return false;
 	}

--- a/connect.cpp
+++ b/connect.cpp
@@ -934,8 +934,8 @@ static int ReConnectSkt(std::shared_ptr<SocketContext>& Skt) {
 
 
 // コマンドコントロールソケットを返す
-SOCKET AskCmdCtrlSkt() {
-	return CmdCtrlSocket->handle;
+std::shared_ptr<SocketContext> AskCmdCtrlSkt() {
+	return CmdCtrlSocket;
 }
 
 

--- a/connect.cpp
+++ b/connect.cpp
@@ -879,7 +879,7 @@ int ReConnectTrnSkt(std::shared_ptr<SocketContext>& Skt, int *CancelCheckWork) {
 //	DisableUserOpe();
 	/* 現在のソケットは切断 */
 	if (Skt)
-		do_closesocket(Skt->handle);
+		Skt->Close();
 	/* 再接続 */
 	// 暗号化通信対応
 	HostData = CurHost;
@@ -918,7 +918,7 @@ static int ReConnectSkt(std::shared_ptr<SocketContext>& Skt) {
 	DisableUserOpe();
 	/* 現在のソケットは切断 */
 	if (Skt)
-		do_closesocket(Skt->handle);
+		Skt->Close();
 	/* 再接続 */
 	if (Skt = DoConnect(&CurHost, CurHost.HostAdrs, CurHost.UserName, CurHost.PassWord, CurHost.Account, CurHost.Port, CurHost.FireWall, NO, CurHost.Security, &CancelFlg)) {
 		SendInitCommand(Skt, CurHost.InitCmd, &CancelFlg);
@@ -1810,20 +1810,20 @@ std::shared_ptr<SocketContext> GetFTPListenSocket(std::shared_ptr<SocketContext>
 			reinterpret_cast<sockaddr_in6&>(saListen).sin6_port = 0;
 		if (bind(listen_skt->handle, reinterpret_cast<const sockaddr*>(&saListen), salen) == SOCKET_ERROR) {
 			WSAError(L"bind()"sv);
-			do_closesocket(listen_skt->handle);
+			listen_skt->Close();
 			Notice(IDS_MSGJPN027);
 			return {};
 		}
 		salen = sizeof saListen;
 		if (getsockname(listen_skt->handle, reinterpret_cast<sockaddr*>(&saListen), &salen) == SOCKET_ERROR) {
 			WSAError(L"getsockname()"sv);
-			do_closesocket(listen_skt->handle);
+			listen_skt->Close();
 			Notice(IDS_MSGJPN027);
 			return {};
 		}
 		if (do_listen(listen_skt->handle, 1) != 0) {
 			WSAError(L"listen()"sv);
-			do_closesocket(listen_skt->handle);
+			listen_skt->Close();
 			Notice(IDS_MSGJPN027);
 			return {};
 		}
@@ -1852,7 +1852,7 @@ std::shared_ptr<SocketContext> GetFTPListenSocket(std::shared_ptr<SocketContext>
 		Notice(IDS_MSGJPN031, saListen.ss_family == AF_INET ? L"PORT"sv : L"EPRT"sv);
 		if (IsUPnPLoaded() == YES)
 			RemovePortMapping(listen_skt->mapPort);
-		do_closesocket(listen_skt->handle);
+		listen_skt->Close();
 		return {};
 	}
 	return listen_skt;

--- a/connect.cpp
+++ b/connect.cpp
@@ -35,8 +35,8 @@
 static int SendInitCommand(SOCKET Socket, std::wstring_view Cmd, int *CancelCheckWork);
 static void AskUseFireWall(std::wstring_view Host, int *Fire, int *Pasv, int *List);
 static void SaveCurrentSetToHistory(void);
-static int ReConnectSkt(SOCKET *Skt);
-static SOCKET DoConnect(HOSTDATA* HostData, std::wstring const& Host, std::wstring& User, std::wstring& Pass, std::wstring& Acct, int Port, int Fwall, int SavePass, int Security, int *CancelCheckWork);
+static int ReConnectSkt(std::shared_ptr<SocketContext>& Skt);
+static std::shared_ptr<SocketContext> DoConnect(HOSTDATA* HostData, std::wstring const& Host, std::wstring& User, std::wstring& Pass, std::wstring& Acct, int Port, int Fwall, int SavePass, int Security, int *CancelCheckWork);
 static std::wstring CheckOneTimePassword(std::wstring&& pass, std::wstring const& reply, int Type);
 
 /*===== 外部参照 =====*/
@@ -67,8 +67,8 @@ extern int UPnPEnabled;
 
 static int Anonymous;
 static int TryConnect = NO;
-static SOCKET CmdCtrlSocket = INVALID_SOCKET;
-static SOCKET TrnCtrlSocket = INVALID_SOCKET;
+static std::shared_ptr<SocketContext> CmdCtrlSocket;
+static std::shared_ptr<SocketContext> TrnCtrlSocket;
 HOSTDATA CurHost;
 
 #if defined(HAVE_TANDEM)
@@ -124,7 +124,7 @@ void ConnectProc(int Type, int Num)
 			SetCurrentHost(Num);
 
 		/* 接続中なら切断する */
-		if(CmdCtrlSocket != INVALID_SOCKET)
+		if (CmdCtrlSocket)
 			DisconnectProc();
 
 		Notice(IDS_SEPARATOR);
@@ -152,8 +152,7 @@ void ConnectProc(int Type, int Num)
 			CmdCtrlSocket = DoConnect(&CurHost, CurHost.HostAdrs, CurHost.UserName, CurHost.PassWord, CurHost.Account, CurHost.Port, CurHost.FireWall, Save, CurHost.Security, &CancelFlg);
 			TrnCtrlSocket = CmdCtrlSocket;
 
-			if(CmdCtrlSocket != INVALID_SOCKET)
-			{
+			if (CmdCtrlSocket) {
 				// 暗号化通信対応
 				switch(CurHost.CryptMode)
 				{
@@ -192,7 +191,7 @@ void ConnectProc(int Type, int Num)
 				UpdateStatusBar();
 				Sound::Connected.Play();
 
-				SendInitCommand(CmdCtrlSocket, CurHost.InitCmd, &CancelFlg);
+				SendInitCommand(CmdCtrlSocket->handle, CurHost.InitCmd, &CancelFlg);
 
 				if (!empty(CurHost.LocalInitDir)) {
 					DoLocalCWD(CurHost.LocalInitDir);
@@ -265,7 +264,7 @@ void QuickConnectProc() {
 
 	if (QuickCon qc; Dialog(GetFtpInst(), hostname_dlg, GetMainHwnd(), qc)) {
 		/* 接続中なら切断する */
-		if (CmdCtrlSocket != INVALID_SOCKET)
+		if (CmdCtrlSocket)
 			DisconnectProc();
 
 		Notice(IDS_SEPARATOR);
@@ -294,7 +293,7 @@ void QuickConnectProc() {
 			CmdCtrlSocket = DoConnect(&CurHost, CurHost.HostAdrs, CurHost.UserName, CurHost.PassWord, CurHost.Account, CurHost.Port, CurHost.FireWall, NO, CurHost.Security, &CancelFlg);
 			TrnCtrlSocket = CmdCtrlSocket;
 
-			if (CmdCtrlSocket != INVALID_SOCKET) {
+			if (CmdCtrlSocket) {
 				TitleHostName = CurHost.HostAdrs;
 				DispWindowTitle();
 				UpdateStatusBar();
@@ -343,7 +342,7 @@ void DirectConnectProc(std::wstring&& unc, int Kanji, int Kana, int Fkanji, int 
 	SaveCurrentSetToHost();
 
 	/* 接続中なら切断する */
-	if(CmdCtrlSocket != INVALID_SOCKET)
+	if (CmdCtrlSocket)
 		DisconnectProc();
 
 	Notice(IDS_SEPARATOR);
@@ -385,8 +384,7 @@ void DirectConnectProc(std::wstring&& unc, int Kanji, int Kana, int Fkanji, int 
 		CmdCtrlSocket = DoConnect(&CurHost, CurHost.HostAdrs, CurHost.UserName, CurHost.PassWord, CurHost.Account, CurHost.Port, CurHost.FireWall, NO, CurHost.Security, &CancelFlg);
 		TrnCtrlSocket = CmdCtrlSocket;
 
-		if(CmdCtrlSocket != INVALID_SOCKET)
-		{
+		if (CmdCtrlSocket) {
 			TitleHostName = CurHost.HostAdrs;
 			DispWindowTitle();
 			UpdateStatusBar();
@@ -434,7 +432,7 @@ void HistoryConnectProc(int MenuCmd)
 		SaveCurrentSetToHost();
 
 		/* 接続中なら切断する */
-		if(CmdCtrlSocket != INVALID_SOCKET)
+		if (CmdCtrlSocket)
 			DisconnectProc();
 
 		Notice(IDS_SEPARATOR);
@@ -461,14 +459,13 @@ void HistoryConnectProc(int MenuCmd)
 			CmdCtrlSocket = DoConnect(&CurHost, CurHost.HostAdrs, CurHost.UserName, CurHost.PassWord, CurHost.Account, CurHost.Port, CurHost.FireWall, NO, CurHost.Security, &CancelFlg);
 			TrnCtrlSocket = CmdCtrlSocket;
 
-			if(CmdCtrlSocket != INVALID_SOCKET)
-			{
+			if (CmdCtrlSocket) {
 				TitleHostName = CurHost.HostAdrs;
 				DispWindowTitle();
 				UpdateStatusBar();
 				Sound::Connected.Play();
 
-				SendInitCommand(CmdCtrlSocket, CurHost.InitCmd, &CancelFlg);
+				SendInitCommand(CmdCtrlSocket->handle, CurHost.InitCmd, &CancelFlg);
 
 				DoLocalCWD(CurHost.LocalInitDir);
 				GetLocalDirForWnd();
@@ -807,8 +804,7 @@ void SaveCurrentSetToHost(void)
 	HOSTDATA TmpHost;
 	TmpHost = CurHost;
 
-	if(TrnCtrlSocket != INVALID_SOCKET)
-	{
+	if (TrnCtrlSocket) {
 		if((Host = AskCurrentHost()) != HOSTNUM_NOENTRY)
 		{
 			// 同時接続対応
@@ -860,32 +856,17 @@ int ReConnectCmdSkt() {
 		result = FFFTP_SUCCESS;
 	} else {
 		if (CmdCtrlSocket == TrnCtrlSocket)
-			TrnCtrlSocket = INVALID_SOCKET;
-		result = ReConnectSkt(&CmdCtrlSocket);
+			TrnCtrlSocket.reset();
+		result = ReConnectSkt(CmdCtrlSocket);
 	}
-	if (TrnCtrlSocket == INVALID_SOCKET)
+	if (!TrnCtrlSocket)
 		TrnCtrlSocket = CmdCtrlSocket;
 	return result;
 }
 
 
-/*----- 転送コントロールソケットの再接続 --------------------------------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		int ステータス
-*			FFFTP_SUCCESS/FFFTP_FAIL
-*----------------------------------------------------------------------------*/
-
-//int ReConnectTrnSkt(void)
-//{
-//	return(ReConnectSkt(&TrnCtrlSocket));
-//}
-// 同時接続対応
-int ReConnectTrnSkt(SOCKET *Skt, int *CancelCheckWork)
-{
+// 転送コントロールソケットの再接続
+int ReConnectTrnSkt(std::shared_ptr<SocketContext>& Skt, int *CancelCheckWork) {
 //	char Path[FMAX_PATH+1];
 	int Sts;
 	// 暗号化通信対応
@@ -897,8 +878,8 @@ int ReConnectTrnSkt(SOCKET *Skt, int *CancelCheckWork)
 
 //	DisableUserOpe();
 	/* 現在のソケットは切断 */
-	if(*Skt != INVALID_SOCKET)
-		do_closesocket(*Skt);
+	if (Skt)
+		do_closesocket(Skt->handle);
 	/* 再接続 */
 	// 暗号化通信対応
 	HostData = CurHost;
@@ -914,9 +895,8 @@ int ReConnectTrnSkt(SOCKET *Skt, int *CancelCheckWork)
 	HostData.CurNameKanjiCode = HostData.NameKanjiCode;
 	// 同時接続対応
 	HostData.NoDisplayUI = YES;
-	if((*Skt = DoConnect(&HostData, CurHost.HostAdrs, CurHost.UserName, CurHost.PassWord, CurHost.Account, CurHost.Port, CurHost.FireWall, NO, CurHost.Security, CancelCheckWork)) != INVALID_SOCKET)
-	{
-		SendInitCommand(*Skt, CurHost.InitCmd, CancelCheckWork);
+	if (Skt = DoConnect(&HostData, CurHost.HostAdrs, CurHost.UserName, CurHost.PassWord, CurHost.Account, CurHost.Port, CurHost.FireWall, NO, CurHost.Security, CancelCheckWork)) {
+		SendInitCommand(Skt->handle, CurHost.InitCmd, CancelCheckWork);
 		Sts = FFFTP_SUCCESS;
 	}
 	else
@@ -927,18 +907,8 @@ int ReConnectTrnSkt(SOCKET *Skt, int *CancelCheckWork)
 }
 
 
-/*----- 回線の再接続 ----------------------------------------------------------
-*
-*	Parameter
-*		SOCKET *Skt : 接続したソケットを返すワーク
-*
-*	Return Value
-*		int ステータス
-*			FFFTP_SUCCESS/FFFTP_FAIL
-*----------------------------------------------------------------------------*/
-
-static int ReConnectSkt(SOCKET *Skt)
-{
+// 回線の再接続
+static int ReConnectSkt(std::shared_ptr<SocketContext>& Skt) {
 	int Sts;
 
 	Sts = FFFTP_FAIL;
@@ -947,12 +917,11 @@ static int ReConnectSkt(SOCKET *Skt)
 
 	DisableUserOpe();
 	/* 現在のソケットは切断 */
-	if(*Skt != INVALID_SOCKET)
-		do_closesocket(*Skt);
+	if (Skt)
+		do_closesocket(Skt->handle);
 	/* 再接続 */
-	if((*Skt = DoConnect(&CurHost, CurHost.HostAdrs, CurHost.UserName, CurHost.PassWord, CurHost.Account, CurHost.Port, CurHost.FireWall, NO, CurHost.Security, &CancelFlg)) != INVALID_SOCKET)
-	{
-		SendInitCommand(*Skt, CurHost.InitCmd, &CancelFlg);
+	if (Skt = DoConnect(&CurHost, CurHost.HostAdrs, CurHost.UserName, CurHost.PassWord, CurHost.Account, CurHost.Port, CurHost.FireWall, NO, CurHost.Security, &CancelFlg)) {
+		SendInitCommand(Skt->handle, CurHost.InitCmd, &CancelFlg);
 		DoCWD(AskRemoteCurDir(), YES, YES, YES);
 		Sts = FFFTP_SUCCESS;
 	}
@@ -964,33 +933,15 @@ static int ReConnectSkt(SOCKET *Skt)
 }
 
 
-/*----- コマンドコントロールソケットを返す ------------------------------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		SOCKET コマンドコントロールソケット
-*----------------------------------------------------------------------------*/
-
-SOCKET AskCmdCtrlSkt(void)
-{
-	return(CmdCtrlSocket);
+// コマンドコントロールソケットを返す
+SOCKET AskCmdCtrlSkt() {
+	return CmdCtrlSocket->handle;
 }
 
 
-/*----- 転送コントロールソケットを返す ----------------------------------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		SOCKET 転送コントロールソケット
-*----------------------------------------------------------------------------*/
-
-SOCKET AskTrnCtrlSkt(void)
-{
-	return(TrnCtrlSocket);
+// 転送コントロールソケットを返す
+std::shared_ptr<SocketContext> AskTrnCtrlSkt() {
+	return TrnCtrlSocket;
 }
 
 
@@ -1010,35 +961,18 @@ void SktShareProh(void)
 		if(CurHost.ReuseCmdSkt == YES)
 		{
 			CurHost.ReuseCmdSkt = NO;
-			CmdCtrlSocket = INVALID_SOCKET;
-			ReConnectSkt(&CmdCtrlSocket);
+			CmdCtrlSocket.reset();
+			ReConnectSkt(CmdCtrlSocket);
 		}
 	}
 	return;
 }
 
 
-/*----- コマンド／転送コントロールソケットの共有が解除されているかチェック ----
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		int ステータス
-*			YES=共有解除/NO=共有
-*----------------------------------------------------------------------------*/
-
-int AskShareProh(void)
-{
-	int Sts;
-
-	Sts = YES;
-	// 同時接続対応
-//	if(CmdCtrlSocket == TrnCtrlSocket)
-	if(CmdCtrlSocket == TrnCtrlSocket || TrnCtrlSocket == INVALID_SOCKET)
-		Sts = NO;
-
-	return(Sts);
+// コマンド／転送コントロールソケットの共有が解除されているかチェック
+//   YES=共有解除/NO=共有
+int AskShareProh() {
+	return CmdCtrlSocket == TrnCtrlSocket || !TrnCtrlSocket ? NO : YES;
 }
 
 
@@ -1055,20 +989,14 @@ void DisconnectProc(void)
 {
 	AbortAllTransfer();
 
-	if((CmdCtrlSocket != INVALID_SOCKET) && (CmdCtrlSocket != TrnCtrlSocket))
-	{
-		// 同時接続対応
-//		DoQUIT(CmdCtrlSocket);
-		DoQUIT(CmdCtrlSocket, &CancelFlg);
-		DoClose(CmdCtrlSocket);
+	if (CmdCtrlSocket && CmdCtrlSocket != TrnCtrlSocket) {
+		DoQUIT(CmdCtrlSocket->handle, &CancelFlg);
+		DoClose(CmdCtrlSocket->handle);
 	}
 
-	if(TrnCtrlSocket != INVALID_SOCKET)
-	{
-		// 同時接続対応
-//		DoQUIT(TrnCtrlSocket);
-		DoQUIT(TrnCtrlSocket, &CancelFlg);
-		DoClose(TrnCtrlSocket);
+	if (TrnCtrlSocket) {
+		DoQUIT(TrnCtrlSocket->handle, &CancelFlg);
+		DoClose(TrnCtrlSocket->handle);
 
 		SaveCurrentSetToHistory();
 
@@ -1076,8 +1004,8 @@ void DisconnectProc(void)
 		Notice(IDS_MSGJPN004);
 	}
 
-	TrnCtrlSocket = INVALID_SOCKET;
-	CmdCtrlSocket = INVALID_SOCKET;
+	TrnCtrlSocket.reset();
+	CmdCtrlSocket.reset();
 
 	DispWindowTitle();
 	UpdateStatusBar();
@@ -1099,8 +1027,8 @@ void DisconnectProc(void)
 
 void DisconnectSet(void)
 {
-	CmdCtrlSocket = INVALID_SOCKET;
-	TrnCtrlSocket = INVALID_SOCKET;
+	CmdCtrlSocket.reset();
+	TrnCtrlSocket.reset();
 
 	EraseRemoteDirForWnd();
 	DispWindowTitle();
@@ -1111,24 +1039,9 @@ void DisconnectSet(void)
 }
 
 
-/*----- ホストに接続中かどうかを返す ------------------------------------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		int ステータス (YES/NO)
-*----------------------------------------------------------------------------*/
-
-int AskConnecting(void)
-{
-	int Sts;
-
-	Sts = NO;
-	if(TrnCtrlSocket != INVALID_SOCKET)
-		Sts = YES;
-
-	return(Sts);
+// ホストに接続中かどうかを返す
+int AskConnecting() {
+	return TrnCtrlSocket ? YES : NO;
 }
 
 
@@ -1224,21 +1137,18 @@ int AskOSS(void)
 *----------------------------------------------------------------------------*/
 
 // 暗号化通信対応
-static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring const& Host, std::wstring& User, std::wstring& Pass, std::wstring& Acct, int Port, int Fwall, int SavePass, int Security, int *CancelCheckWork)
+static std::shared_ptr<SocketContext> DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring const& Host, std::wstring& User, std::wstring& Pass, std::wstring& Acct, int Port, int Fwall, int SavePass, int Security, int *CancelCheckWork)
 {
 	int Sts;
 	int Flg;
 	int Anony;
-	SOCKET ContSock;
+	std::shared_ptr<SocketContext> ContSock;
 	int Continue;
 	int ReInPass;
 	constexpr std::wstring_view SiteTbl[] = { L"SITE"sv, L"site"sv, L"OPEN"sv, L"open"sv };
 	struct linger LingerOpt;
 	struct tcp_keepalive KeepAlive;
 	DWORD dwTmp;
-
-	// 暗号化通信対応
-	ContSock = INVALID_SOCKET;
 
 	if(CryptMode == CRYPT_NONE || CryptMode == CRYPT_FTPES || CryptMode == CRYPT_FTPIS)
 	{
@@ -1254,22 +1164,20 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring con
 //		WSASetBlockingHook(BlkHookFnc);
 #endif
 
-		ContSock = INVALID_SOCKET;
-
 		auto [tempHost, tempPort] = FWALL_FU_FP_SITE <= Fwall && Fwall <= FWALL_OPEN || Fwall == FWALL_SIDEWINDER || Fwall == FWALL_FU_FP ? std::tuple{ FwallHost, FwallPort } : std::tuple{ Host, Port };
 		if (!empty(tempHost)) {
-			if ((ContSock = connectsock(std::move(tempHost), tempPort, 0, CancelCheckWork)) != INVALID_SOCKET) {
+			if (ContSock = connectsock(std::move(tempHost), tempPort, 0, CancelCheckWork)) {
 				// バッファを無効
 #ifdef DISABLE_CONTROL_NETWORK_BUFFERS
 				int BufferSize = 0;
-				setsockopt(ContSock, SOL_SOCKET, SO_SNDBUF, (char*)&BufferSize, sizeof(int));
-				setsockopt(ContSock, SOL_SOCKET, SO_RCVBUF, (char*)&BufferSize, sizeof(int));
+				setsockopt(ContSock->handle, SOL_SOCKET, SO_SNDBUF, (char*)&BufferSize, sizeof(int));
+				setsockopt(ContSock->handle, SOL_SOCKET, SO_RCVBUF, (char*)&BufferSize, sizeof(int));
 #endif
 				if(CryptMode == CRYPT_FTPIS)
 				{
-					if(AttachSSL(ContSock, INVALID_SOCKET, CancelCheckWork, Host))
+					if(AttachSSL(ContSock->handle, INVALID_SOCKET, CancelCheckWork, Host))
 					{
-						while((Sts = std::get<0>(ReadReplyMessage(ContSock, CancelCheckWork)) / 100) == FTP_PRELIM)
+						while((Sts = std::get<0>(ReadReplyMessage(ContSock->handle, CancelCheckWork)) / 100) == FTP_PRELIM)
 							;
 					}
 					else
@@ -1277,21 +1185,21 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring con
 				}
 				else
 				{
-					while((Sts = std::get<0>(ReadReplyMessage(ContSock, CancelCheckWork)) / 100) == FTP_PRELIM)
+					while((Sts = std::get<0>(ReadReplyMessage(ContSock->handle, CancelCheckWork)) / 100) == FTP_PRELIM)
 						;
 				}
 
 				if(Sts == FTP_COMPLETE)
 				{
 					Flg = 1;
-					if(setsockopt(ContSock, SOL_SOCKET, SO_OOBINLINE, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
+					if(setsockopt(ContSock->handle, SOL_SOCKET, SO_OOBINLINE, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
 						WSAError(L"setsockopt(SOL_SOCKET, SO_OOBINLINE)"sv);
 					// データ転送用ソケットのTCP遅延転送が無効されているので念のため
-					if(setsockopt(ContSock, IPPROTO_TCP, TCP_NODELAY, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
+					if(setsockopt(ContSock->handle, IPPROTO_TCP, TCP_NODELAY, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
 						WSAError(L"setsockopt(IPPROTO_TCP, TCP_NODELAY)"sv);
 //#pragma aaa
 					Flg = 1;
-					if(setsockopt(ContSock, SOL_SOCKET, SO_KEEPALIVE, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
+					if(setsockopt(ContSock->handle, SOL_SOCKET, SO_KEEPALIVE, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
 						WSAError(L"setsockopt(SOL_SOCKET, SO_KEEPALIVE)"sv);
 					// 切断対策
 					if(TimeOut > 0)
@@ -1299,12 +1207,12 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring con
 						KeepAlive.onoff = 1;
 						KeepAlive.keepalivetime = TimeOut * 1000;
 						KeepAlive.keepaliveinterval = 1000;
-						if(WSAIoctl(ContSock, SIO_KEEPALIVE_VALS, &KeepAlive, sizeof(struct tcp_keepalive), NULL, 0, &dwTmp, NULL, NULL) == SOCKET_ERROR)
+						if(WSAIoctl(ContSock->handle, SIO_KEEPALIVE_VALS, &KeepAlive, sizeof(struct tcp_keepalive), NULL, 0, &dwTmp, NULL, NULL) == SOCKET_ERROR)
 							WSAError(L"WSAIoctl(SIO_KEEPALIVE_VALS)"sv);
 					}
 					LingerOpt.l_onoff = 1;
 					LingerOpt.l_linger = 90;
-					if(setsockopt(ContSock, SOL_SOCKET, SO_LINGER, (LPSTR)&LingerOpt, sizeof(LingerOpt)) == SOCKET_ERROR)
+					if(setsockopt(ContSock->handle, SOL_SOCKET, SO_LINGER, (LPSTR)&LingerOpt, sizeof(LingerOpt)) == SOCKET_ERROR)
 						WSAError(L"setsockopt(SOL_SOCKET, SO_LINGER)"sv);
 ///////
 
@@ -1316,20 +1224,20 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring con
 					   (Fwall == FWALL_FU_FP_USER) ||
 					   (Fwall == FWALL_FU_FP))
 					{
-						if (auto [code, text] = Command(ContSock, CancelCheckWork, L"USER {}"sv, FwallUser); (Sts = code / 100) == FTP_CONTINUE) {
+						if (auto [code, text] = Command(ContSock->handle, CancelCheckWork, L"USER {}"sv, FwallUser); (Sts = code / 100) == FTP_CONTINUE) {
 							auto const pass = CheckOneTimePassword(std::wstring{ FwallPass }, text, FwallSecurity);
-							Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"PASS {}"sv, pass)) / 100;
+							Sts = std::get<0>(Command(ContSock->handle, CancelCheckWork, L"PASS {}"sv, pass)) / 100;
 						}
 					}
 					else if(Fwall == FWALL_SIDEWINDER)
 					{
-						Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"USER {}:{}{}{}"sv, FwallUser, FwallPass, (wchar_t)FwallDelimiter, Host)) / 100;
+						Sts = std::get<0>(Command(ContSock->handle, CancelCheckWork, L"USER {}:{}{}{}"sv, FwallUser, FwallPass, (wchar_t)FwallDelimiter, Host)) / 100;
 					}
 					if((Sts != FTP_COMPLETE) && (Sts != FTP_CONTINUE))
 					{
 						Notice(IDS_MSGJPN006);
-						DoClose(ContSock);
-						ContSock = INVALID_SOCKET;
+						DoClose(ContSock->handle);
+						ContSock.reset();
 					}
 					else
 					{
@@ -1337,14 +1245,14 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring con
 						{
 							int index = (Fwall == FWALL_OPEN ? 2 : 0) | (FwallLower == YES ? 1 : 0);
 							auto format = Port == IPPORT_FTP ? L"{} {}"sv : L"{} {} {}"sv;
-							Sts = std::get<0>(Command(ContSock, CancelCheckWork, format, SiteTbl[index], Host)) / 100;
+							Sts = std::get<0>(Command(ContSock->handle, CancelCheckWork, format, SiteTbl[index], Host)) / 100;
 						}
 
 						if((Sts != FTP_COMPLETE) && (Sts != FTP_CONTINUE))
 						{
 							Notice(IDS_MSGJPN007, Host);
-							DoClose(ContSock);
-							ContSock = INVALID_SOCKET;
+							DoClose(ContSock->handle);
+							ContSock.reset();
 						}
 						else
 						{
@@ -1362,21 +1270,21 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring con
 
 								// FTPES対応
 								if (CryptMode == CRYPT_FTPES) {
-									if ((Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"AUTH TLS"sv))) != 234 && (Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"AUTH SSL"sv))) != 234)
+									if ((Sts = std::get<0>(Command(ContSock->handle, CancelCheckWork, L"AUTH TLS"sv))) != 234 && (Sts = std::get<0>(Command(ContSock->handle, CancelCheckWork, L"AUTH SSL"sv))) != 234)
 										Sts = FTP_ERROR;
-									else if (!AttachSSL(ContSock, INVALID_SOCKET, CancelCheckWork, Host))
+									else if (!AttachSSL(ContSock->handle, INVALID_SOCKET, CancelCheckWork, Host))
 										Sts = FTP_ERROR;
-									else if ((Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"PBSZ 0"sv))) != 200)
+									else if ((Sts = std::get<0>(Command(ContSock->handle, CancelCheckWork, L"PBSZ 0"sv))) != 200)
 										Sts = FTP_ERROR;
-									else if ((Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"PROT P"sv))) != 200)
+									else if ((Sts = std::get<0>(Command(ContSock->handle, CancelCheckWork, L"PROT P"sv))) != 200)
 										Sts = FTP_ERROR;
 								}
 
 								// FTPIS対応
 								if (CryptMode == CRYPT_FTPIS) {
 									// "PBSZ 0"と"PROT P"は黙示的に設定されているはずだが念のため
-									if ((Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"PBSZ 0"sv))) == 200)
-										Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"PROT P"sv));
+									if ((Sts = std::get<0>(Command(ContSock->handle, CancelCheckWork, L"PBSZ 0"sv))) == 200)
+										Sts = std::get<0>(Command(ContSock->handle, CancelCheckWork, L"PROT P"sv));
 								}
 
 								ReInPass = NO;
@@ -1386,7 +1294,7 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring con
 									if(Sts == FTP_ERROR)
 										break;
 									Continue = NO;
-									if (auto [code, text] = Command(ContSock, CancelCheckWork, L"USER {}"sv, user); (Sts = code / 100) == FTP_CONTINUE)
+									if (auto [code, text] = Command(ContSock->handle, CancelCheckWork, L"USER {}"sv, user); (Sts = code / 100) == FTP_CONTINUE)
 									{
 										if (empty(Pass) && HostData->NoDisplayUI == NO)
 											InputDialog(passwd_dlg, GetMainHwnd(), 0, Pass, PASSWORD_LEN + 1);
@@ -1396,7 +1304,7 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring con
 											/* パスワードがスペース1個の時はパスワードの実体なしとする */
 											if (pass == L" "sv)
 												pass = L""s;
-											Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"PASS {}"sv, pass)) / 100;
+											Sts = std::get<0>(Command(ContSock->handle, CancelCheckWork, L"PASS {}"sv, pass)) / 100;
 											if(Sts == FTP_ERROR)
 											{
 												if (HostData->NoDisplayUI == NO && InputDialog(re_passwd_dlg, GetMainHwnd(), 0, Pass, PASSWORD_LEN + 1))
@@ -1412,7 +1320,7 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring con
 												if (empty(Acct) && HostData->NoDisplayUI == NO)
 													InputDialog(account_dlg, GetMainHwnd(), 0, Acct, ACCOUNT_LEN + 1);
 												if (!empty(Acct))
-													Sts = std::get<0>(Command(ContSock, CancelCheckWork, L"ACCT {}", Acct)) / 100;
+													Sts = std::get<0>(Command(ContSock->handle, CancelCheckWork, L"ACCT {}", Acct)) / 100;
 												else
 													Debug(L"No account specified."sv);
 											}
@@ -1438,8 +1346,8 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring con
 							if(Sts != FTP_COMPLETE)
 							{
 								Notice(IDS_MSGJPN008);
-								DoClose(ContSock);
-								ContSock = INVALID_SOCKET;
+								DoClose(ContSock->handle);
+								ContSock.reset();
 							}
 							else if((SavePass == YES) && (ReInPass == YES))
 							{
@@ -1452,8 +1360,8 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring con
 				else
 				{
 				Notice(IDS_MSGJPN009);
-					DoClose(ContSock);
-					ContSock = INVALID_SOCKET;
+					DoClose(ContSock->handle);
+					ContSock.reset();
 				}
 			}
 		}
@@ -1474,9 +1382,8 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring con
 
 		// FEAT対応
 		// ホストの機能を確認
-		if(ContSock != INVALID_SOCKET)
-		{
-			if (auto [code, text] = Command(ContSock, CancelCheckWork, L"FEAT"sv); code == 211) {
+		if (ContSock) {
+			if (auto [code, text] = Command(ContSock->handle, CancelCheckWork, L"FEAT"sv); code == 211) {
 				// 改行文字はReadReplyMessageで消去されるため区切り文字に空白を使用
 				if (text.find(L" UTF8 "sv) != std::wstring::npos)
 					HostData->Feature |= FEATURE_UTF8;
@@ -1490,14 +1397,14 @@ static SOCKET DoConnectCrypt(int CryptMode, HOSTDATA* HostData, std::wstring con
 					HostData->Feature |= FEATURE_MFMT;
 			}
 			if (HostData->CurNameKanjiCode == KANJI_AUTO && (HostData->Feature & FEATURE_UTF8))
-				Command(ContSock, CancelCheckWork, L"OPTS UTF8 ON"sv);
+				Command(ContSock->handle, CancelCheckWork, L"OPTS UTF8 ON"sv);
 		}
 	}
 
 	return(ContSock);
 }
 
-static SOCKET DoConnect(HOSTDATA* HostData, std::wstring const& Host, std::wstring& User, std::wstring& Pass, std::wstring& Acct, int Port, int Fwall, int SavePass, int Security, int* CancelCheckWork) {
+static std::shared_ptr<SocketContext> DoConnect(HOSTDATA* HostData, std::wstring const& Host, std::wstring& User, std::wstring& Pass, std::wstring& Acct, int Port, int Fwall, int SavePass, int Security, int* CancelCheckWork) {
 	constexpr struct {
 		int HOSTDATA::* ptr;
 		int msgid;
@@ -1507,12 +1414,12 @@ static SOCKET DoConnect(HOSTDATA* HostData, std::wstring const& Host, std::wstri
 		{ &HOSTDATA::UseFTPES, IDS_MSGJPN315, CRYPT_FTPES },
 		{ &HOSTDATA::UseNoEncryption, IDS_MSGJPN314, CRYPT_NONE },
 	};
-	SOCKET ContSock = INVALID_SOCKET;
+	std::shared_ptr<SocketContext> ContSock;
 	*CancelCheckWork = NO;
 	for (auto [ptr, msgid, cryptMode] : pattern)
-		if (*CancelCheckWork == NO && ContSock == INVALID_SOCKET && HostData->*ptr == YES) {
+		if (*CancelCheckWork == NO && !ContSock && HostData->*ptr == YES) {
 			Notice(msgid);
-			if ((ContSock = DoConnectCrypt(cryptMode, HostData, Host, User, Pass, Acct, Port, Fwall, SavePass, Security, CancelCheckWork)) != INVALID_SOCKET)
+			if (ContSock = DoConnectCrypt(cryptMode, HostData, Host, User, Pass, Acct, Port, Fwall, SavePass, Security, CancelCheckWork))
 				HostData->CryptMode = cryptMode;
 		}
 	return ContSock;
@@ -1802,7 +1709,7 @@ static std::optional<sockaddr_storage> SocksRequest(SOCKET s, SocksCommand cmd, 
 }
 
 
-SOCKET connectsock(std::wstring&& host, int port, UINT prefixId, int *CancelCheckWork) {
+std::shared_ptr<SocketContext> connectsock(std::wstring&& host, int port, UINT prefixId, int *CancelCheckWork) {
 	std::variant<sockaddr_storage, std::tuple<std::wstring, int>> target;
 	int Fwall = AskHostFireWall() == YES ? FwallType : FWALL_NONE;
 	if (auto ai = getaddrinfo(host, port, Fwall == FWALL_SOCKS4 ? AF_INET : AF_UNSPEC)) {
@@ -1819,7 +1726,7 @@ SOCKET connectsock(std::wstring&& host, int port, UINT prefixId, int *CancelChec
 	} else {
 		// 名前解決に失敗
 		Notice(IDS_MSGJPN019, host);
-		return INVALID_SOCKET;
+		return {};
 	}
 
 	sockaddr_storage saConnect;
@@ -1830,7 +1737,7 @@ SOCKET connectsock(std::wstring&& host, int port, UINT prefixId, int *CancelChec
 			ai = getaddrinfo(FwallHost, FwallPort, AF_UNSPEC, CancelCheckWork);
 		if (!ai) {
 			Notice(IDS_MSGJPN021, FwallHost);
-			return INVALID_SOCKET;
+			return {};
 		}
 		memcpy(&saConnect, ai->ai_addr, ai->ai_addrlen);
 		Notice(IDS_MSGJPN022, AddressPortToString(ai->ai_addr, ai->ai_addrlen));
@@ -1839,23 +1746,23 @@ SOCKET connectsock(std::wstring&& host, int port, UINT prefixId, int *CancelChec
 		saConnect = std::get<sockaddr_storage>(target);
 	}
 
-	auto s = do_socket(saConnect.ss_family, SOCK_STREAM, IPPROTO_TCP);
-	if (s == INVALID_SOCKET) {
+	auto s = SocketContext::Create(saConnect.ss_family, SOCK_STREAM, IPPROTO_TCP);
+	if (!s) {
 		Notice(IDS_MSGJPN027);
-		return INVALID_SOCKET;
+		return {};
 	}
-	SetAsyncTableData(s, target);
-	if (do_connect(s, reinterpret_cast<const sockaddr*>(&saConnect), sizeof saConnect, CancelCheckWork) == SOCKET_ERROR) {
+	SetAsyncTableData(s->handle, target);
+	if (do_connect(s->handle, reinterpret_cast<const sockaddr*>(&saConnect), sizeof saConnect, CancelCheckWork) == SOCKET_ERROR) {
 		Notice(IDS_MSGJPN026);
-		DoClose(s);
-		return INVALID_SOCKET;
+		DoClose(s->handle);
+		return {};
 	}
 	if (Fwall == FWALL_SOCKS4 || Fwall == FWALL_SOCKS5_NOAUTH || Fwall == FWALL_SOCKS5_USER) {
-		auto result = SocksRequest(s, SocksCommand::Connect, target, CancelCheckWork);
+		auto result = SocksRequest(s->handle, SocksCommand::Connect, target, CancelCheckWork);
 		if (!result) {
 			Notice(IDS_MSGJPN023);
-			DoClose(s);
-			return INVALID_SOCKET;
+			DoClose(s->handle);
+			return {};
 		}
 		CurHost.CurNetType = result->ss_family == AF_INET ? NTYPE_IPV4 : NTYPE_IPV6;
 	} else
@@ -1866,35 +1773,35 @@ SOCKET connectsock(std::wstring&& host, int port, UINT prefixId, int *CancelChec
 
 
 // リッスンソケットを取得
-SOCKET GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork) {
+std::shared_ptr<SocketContext> GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork) {
 	sockaddr_storage saListen;
 	int salen = sizeof saListen;
 	if (getsockname(ctrl_skt, reinterpret_cast<sockaddr*>(&saListen), &salen) == SOCKET_ERROR) {
 		WSAError(L"getsockname()"sv);
-		return INVALID_SOCKET;
+		return {};
 	}
-	auto listen_skt = do_socket(saListen.ss_family, SOCK_STREAM, IPPROTO_TCP);
-	if (listen_skt == INVALID_SOCKET)
-		return INVALID_SOCKET;
+	auto listen_skt = SocketContext::Create(saListen.ss_family, SOCK_STREAM, IPPROTO_TCP);
+	if (!listen_skt)
+		return {};
 	if (AskHostFireWall() == YES && (FwallType == FWALL_SOCKS4 || FwallType == FWALL_SOCKS5_NOAUTH || FwallType == FWALL_SOCKS5_USER)) {
 		Debug(L"Use SOCKS BIND."sv);
 		// Control接続と同じアドレスに接続する
 		salen = sizeof saListen;
 		if (getpeername(ctrl_skt, reinterpret_cast<sockaddr*>(&saListen), &salen) == SOCKET_ERROR) {
 			WSAError(L"getpeername()"sv);
-			return INVALID_SOCKET;
+			return {};
 		}
-		if (do_connect(listen_skt, reinterpret_cast<const sockaddr*>(&saListen), salen, CancelCheckWork) == SOCKET_ERROR) {
-			return INVALID_SOCKET;
+		if (do_connect(listen_skt->handle, reinterpret_cast<const sockaddr*>(&saListen), salen, CancelCheckWork) == SOCKET_ERROR) {
+			return {};
 		}
 		std::variant<sockaddr_storage, std::tuple<std::wstring, int>> target;
 		GetAsyncTableData(ctrl_skt, target);
-		if (auto result = SocksRequest(listen_skt, SocksCommand::Bind, target, CancelCheckWork)) {
+		if (auto result = SocksRequest(listen_skt->handle, SocksCommand::Bind, target, CancelCheckWork)) {
 			saListen = *result;
 		} else {
 			Notice(IDS_MSGJPN023);
-			DoClose(listen_skt);
-			return INVALID_SOCKET;
+			DoClose(listen_skt->handle);
+			return {};
 		}
 	} else {
 		Debug(L"Use normal BIND."sv);
@@ -1903,24 +1810,24 @@ SOCKET GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork) {
 			reinterpret_cast<sockaddr_in&>(saListen).sin_port = 0;
 		else
 			reinterpret_cast<sockaddr_in6&>(saListen).sin6_port = 0;
-		if (bind(listen_skt, reinterpret_cast<const sockaddr*>(&saListen), salen) == SOCKET_ERROR) {
+		if (bind(listen_skt->handle, reinterpret_cast<const sockaddr*>(&saListen), salen) == SOCKET_ERROR) {
 			WSAError(L"bind()"sv);
-			do_closesocket(listen_skt);
+			do_closesocket(listen_skt->handle);
 			Notice(IDS_MSGJPN027);
-			return INVALID_SOCKET;
+			return {};
 		}
 		salen = sizeof saListen;
-		if (getsockname(listen_skt, reinterpret_cast<sockaddr*>(&saListen), &salen) == SOCKET_ERROR) {
+		if (getsockname(listen_skt->handle, reinterpret_cast<sockaddr*>(&saListen), &salen) == SOCKET_ERROR) {
 			WSAError(L"getsockname()"sv);
-			do_closesocket(listen_skt);
+			do_closesocket(listen_skt->handle);
 			Notice(IDS_MSGJPN027);
-			return INVALID_SOCKET;
+			return {};
 		}
-		if (do_listen(listen_skt, 1) != 0) {
+		if (do_listen(listen_skt->handle, 1) != 0) {
 			WSAError(L"listen()"sv);
-			do_closesocket(listen_skt);
+			do_closesocket(listen_skt->handle);
 			Notice(IDS_MSGJPN027);
-			return INVALID_SOCKET;
+			return {};
 		}
 		// TODO: IPv6にUPnP NATは無意味なのでは？
 		if (IsUPnPLoaded() == YES && UPnPEnabled == YES) {
@@ -1929,7 +1836,7 @@ SOCKET GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork) {
 			if (auto const ExtAdrs = AddPortMapping(AddressToString(saListen), port))
 				if (auto ai = getaddrinfo(*ExtAdrs, port)) {
 					memcpy(&saListen, ai->ai_addr, ai->ai_addrlen);
-					SetAsyncTableDataMapPort(listen_skt, port);
+					SetAsyncTableDataMapPort(listen_skt->handle, port);
 				}
 		}
 	}
@@ -1946,10 +1853,10 @@ SOCKET GetFTPListenSocket(SOCKET ctrl_skt, int *CancelCheckWork) {
 	if (status / 100 != FTP_COMPLETE) {
 		Notice(IDS_MSGJPN031, saListen.ss_family == AF_INET ? L"PORT"sv : L"EPRT"sv);
 		if (IsUPnPLoaded() == YES)
-			if (int port; GetAsyncTableDataMapPort(listen_skt, &port) == YES)
+			if (int port; GetAsyncTableDataMapPort(listen_skt->handle, &port) == YES)
 				RemovePortMapping(port);
-		do_closesocket(listen_skt);
-		return INVALID_SOCKET;
+		do_closesocket(listen_skt->handle);
+		return {};
 	}
 	return listen_skt;
 }

--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -2365,7 +2365,7 @@ void AbortRecoveryProc(void)
 				EnableUserOpe();
 			}
 			else
-				RemoveReceivedData(AskCmdCtrlSkt()->handle);
+				RemoveReceivedData(AskCmdCtrlSkt());
 		}
 	}
 	return;

--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -1577,7 +1577,7 @@ static void DelNotifyAndDo(FILELIST const& Dt, int Win, int* Sw, int* Flg, std::
 			*Flg = YES;
 		} else {
 			/* フルパスを使わない時のための処理 */
-			if (ProcForNonFullpath(AskCmdCtrlSkt(), path, CurDir, GetMainHwnd(), &CancelFlg) == FFFTP_FAIL)
+			if (ProcForNonFullpath(AskCmdCtrlSkt()->handle, path, CurDir, GetMainHwnd(), &CancelFlg) == FFFTP_FAIL)
 				*Sw = NO_ALL;
 			if (*Sw != NO_ALL) {
 				if (Dt.Node == NODE_FILE)
@@ -2150,7 +2150,7 @@ void SomeCmdProc(void)
 			MakeSelectedFileList(WIN_REMOTE, NO, NO, FileListBase, &CancelFlg);
 			auto cmd = empty(FileListBase) ? L""s : FileListBase[0].Name;
 			if (InputDialog(somecmd_dlg, GetMainHwnd(), 0, cmd, 81, nullptr, IDH_HELP_TOPIC_0000023))
-				DoQUOTE(AskCmdCtrlSkt(), cmd, &CancelFlg);
+				DoQUOTE(AskCmdCtrlSkt()->handle, cmd, &CancelFlg);
 			EnableUserOpe();
 		}
 	}
@@ -2365,7 +2365,7 @@ void AbortRecoveryProc(void)
 				EnableUserOpe();
 			}
 			else
-				RemoveReceivedData(AskCmdCtrlSkt());
+				RemoveReceivedData(AskCmdCtrlSkt()->handle);
 		}
 	}
 	return;

--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -2288,7 +2288,7 @@ int ProcForNonFullpath(std::shared_ptr<SocketContext> cSkt, std::wstring& Path, 
 	if (AskNoFullPathMode() == YES) {
 		auto Tmp = AskHostType() == HTYPE_VMS ? ReformToVMSstyleDirName(std::wstring{ GetUpperDirEraseTopSlash(Path) }) : AskHostType() == HTYPE_STRATUS ? std::wstring{ GetUpperDirEraseTopSlash(Path) } : std::wstring{ GetUpperDir(Path) };
 		if (Tmp != CurDir) {
-			if (int code = std::get<0>(Command(cSkt->handle, CancelCheckWork, L"CWD {}"sv, Tmp)); code / 100 != FTP_COMPLETE) {
+			if (int code = std::get<0>(Command(cSkt, CancelCheckWork, L"CWD {}"sv, Tmp)); code / 100 != FTP_COMPLETE) {
 				DispCWDerror(hWnd);
 				Sts = FFFTP_FAIL;
 			} else

--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -1577,7 +1577,7 @@ static void DelNotifyAndDo(FILELIST const& Dt, int Win, int* Sw, int* Flg, std::
 			*Flg = YES;
 		} else {
 			/* フルパスを使わない時のための処理 */
-			if (ProcForNonFullpath(AskCmdCtrlSkt()->handle, path, CurDir, GetMainHwnd(), &CancelFlg) == FFFTP_FAIL)
+			if (ProcForNonFullpath(AskCmdCtrlSkt(), path, CurDir, GetMainHwnd(), &CancelFlg) == FFFTP_FAIL)
 				*Sw = NO_ALL;
 			if (*Sw != NO_ALL) {
 				if (Dt.Node == NODE_FILE)
@@ -2283,12 +2283,12 @@ static std::wstring_view GetUpperDir(std::wstring_view path) {
 
 // フルパスを使わないファイルアクセスの準備
 //   フルパスを使わない時は、このモジュール内で CWD を行ない、Path にファイル名のみ残す。（パス名は消す）
-int ProcForNonFullpath(SOCKET cSkt, std::wstring& Path, std::wstring& CurDir, HWND hWnd, int* CancelCheckWork) {
+int ProcForNonFullpath(std::shared_ptr<SocketContext> cSkt, std::wstring& Path, std::wstring& CurDir, HWND hWnd, int* CancelCheckWork) {
 	int Sts = FFFTP_SUCCESS;
 	if (AskNoFullPathMode() == YES) {
 		auto Tmp = AskHostType() == HTYPE_VMS ? ReformToVMSstyleDirName(std::wstring{ GetUpperDirEraseTopSlash(Path) }) : AskHostType() == HTYPE_STRATUS ? std::wstring{ GetUpperDirEraseTopSlash(Path) } : std::wstring{ GetUpperDir(Path) };
 		if (Tmp != CurDir) {
-			if (int code = std::get<0>(Command(cSkt, CancelCheckWork, L"CWD {}"sv, Tmp)); code / 100 != FTP_COMPLETE) {
+			if (int code = std::get<0>(Command(cSkt->handle, CancelCheckWork, L"CWD {}"sv, Tmp)); code / 100 != FTP_COMPLETE) {
 				DispCWDerror(hWnd);
 				Sts = FFFTP_FAIL;
 			} else

--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -2364,8 +2364,10 @@ void AbortRecoveryProc(void)
 				GetRemoteDirForWnd(CACHE_REFRESH, &CancelFlg);
 				EnableUserOpe();
 			}
-			else
-				RemoveReceivedData(AskCmdCtrlSkt());
+			else {
+				if (auto sc = AskCmdCtrlSkt())
+					sc->RemoveReceivedData();
+			}
 		}
 	}
 	return;

--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -2150,7 +2150,7 @@ void SomeCmdProc(void)
 			MakeSelectedFileList(WIN_REMOTE, NO, NO, FileListBase, &CancelFlg);
 			auto cmd = empty(FileListBase) ? L""s : FileListBase[0].Name;
 			if (InputDialog(somecmd_dlg, GetMainHwnd(), 0, cmd, 81, nullptr, IDH_HELP_TOPIC_0000023))
-				DoQUOTE(AskCmdCtrlSkt()->handle, cmd, &CancelFlg);
+				DoQUOTE(AskCmdCtrlSkt(), cmd, &CancelFlg);
 			EnableUserOpe();
 		}
 	}

--- a/getput.cpp
+++ b/getput.cpp
@@ -2212,9 +2212,7 @@ static std::optional<std::tuple<std::wstring, int>> GetAdrsAndPort(std::shared_p
 		} else
 			return {};
 	}
-	std::variant<sockaddr_storage, std::tuple<std::wstring, int>> target;
-	GetAsyncTableData(socket->handle, target);
-	addr = target.index() == 0 ? AddressToString(std::get<0>(target)) : std::get<0>(std::get<1>(target));
+	addr = socket->target.index() == 0 ? AddressToString(std::get<0>(socket->target)) : std::get<0>(std::get<1>(socket->target));
 	return { { addr, port } };
 }
 

--- a/getput.cpp
+++ b/getput.cpp
@@ -1101,8 +1101,6 @@ static int DownloadNonPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 	std::shared_ptr<SocketContext> data_socket;   // data channel socket
 	std::shared_ptr<SocketContext> listen_socket; // data listen socket
 	int CreateMode;
-	// UPnP対応
-	int Port;
 
 	if (listen_socket = GetFTPListenSocket(Pkt->ctrl_skt, CancelCheckWork)) {
 		if(SetDownloadResume(Pkt, Pkt->Mode, Pkt->ExistSize, &CreateMode, CancelCheckWork) == YES)
@@ -1127,10 +1125,7 @@ static int DownloadNonPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 						WSAError(L"shutdown(listen)"sv);
 					// UPnP対応
 					if(IsUPnPLoaded() == YES)
-					{
-						if(GetAsyncTableDataMapPort(listen_socket->handle, &Port) == YES)
-							RemovePortMapping(Port);
-					}
+						RemovePortMapping(listen_socket->mapPort);
 					DoClose(listen_socket->handle);
 					listen_socket.reset();
 
@@ -1163,10 +1158,7 @@ static int DownloadNonPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 				Notice(IDS_MSGJPN090);
 				// UPnP対応
 				if(IsUPnPLoaded() == YES)
-				{
-					if(GetAsyncTableDataMapPort(listen_socket->handle, &Port) == YES)
-						RemovePortMapping(Port);
-				}
+					RemovePortMapping(listen_socket->mapPort);
 				DoClose(listen_socket->handle);
 				listen_socket.reset();
 				iRetCode = 500;
@@ -1178,10 +1170,7 @@ static int DownloadNonPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 		{
 			// UPnP対応
 			if(IsUPnPLoaded() == YES)
-			{
-				if(GetAsyncTableDataMapPort(listen_socket->handle, &Port) == YES)
-					RemovePortMapping(Port);
-			}
+				RemovePortMapping(listen_socket->mapPort);
 			DoClose(listen_socket->handle);
 			listen_socket.reset();
 			iRetCode = 500;
@@ -1637,7 +1626,6 @@ static int UploadNonPassive(TRANSPACKET *Pkt)
 	int iRetCode;
 	std::shared_ptr<SocketContext> data_socket;   // data channel socket
 	std::shared_ptr<SocketContext> listen_socket; // data listen socket
-	int Port;
 	int Resume;
 
 	if (listen_socket = GetFTPListenSocket(Pkt->ctrl_skt, &Canceled[Pkt->ThreadCount])) {
@@ -1676,10 +1664,7 @@ static int UploadNonPassive(TRANSPACKET *Pkt)
 					WSAError(L"shutdown(listen)"sv);
 				// UPnP対応
 				if(IsUPnPLoaded() == YES)
-				{
-					if(GetAsyncTableDataMapPort(listen_socket->handle, &Port) == YES)
-						RemovePortMapping(Port);
-				}
+					RemovePortMapping(listen_socket->mapPort);
 				DoClose(listen_socket->handle);
 				listen_socket.reset();
 
@@ -1716,10 +1701,7 @@ static int UploadNonPassive(TRANSPACKET *Pkt)
 			Notice(IDS_MSGJPN108);
 			// UPnP対応
 			if(IsUPnPLoaded() == YES)
-			{
-				if(GetAsyncTableDataMapPort(listen_socket->handle, &Port) == YES)
-					RemovePortMapping(Port);
-			}
+				RemovePortMapping(listen_socket->mapPort);
 			DoClose(listen_socket->handle);
 			listen_socket.reset();
 			iRetCode = 500;

--- a/getput.cpp
+++ b/getput.cpp
@@ -1142,7 +1142,7 @@ static int DownloadNonPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 					// 一部TYPE、STOR(RETR)、PORT(PASV)を並列に処理できないホストがあるため
 					ReleaseMutex(hListAccMutex);
 					if (Pkt->ctrl_skt->IsSSLAttached()) {
-						if (data_socket->AttachSSL(Pkt->ctrl_skt.get(), CancelCheckWork, {}))
+						if (data_socket->AttachSSL(CancelCheckWork))
 							iRetCode = DownloadFile(Pkt, data_socket, CreateMode, CancelCheckWork);
 						else
 							iRetCode = 500;
@@ -1206,7 +1206,7 @@ static int DownloadPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 	if(iRetCode/100 == FTP_COMPLETE)
 	{
 		if (auto const target = GetAdrsAndPort(Pkt->ctrl_skt, text)) {
-			if (auto [host, port] = *target; data_socket = connectsock(std::move(host), port, IDS_MSGJPN091, CancelCheckWork)) {
+			if (auto [host, port] = *target; data_socket = connectsock(*Pkt->ctrl_skt, std::move(host), port, IDS_MSGJPN091, CancelCheckWork)) {
 				// 変数が未初期化のバグ修正
 				Flg = 1;
 				if(setsockopt(data_socket->handle, IPPROTO_TCP, TCP_NODELAY, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
@@ -1220,7 +1220,7 @@ static int DownloadPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 						// 一部TYPE、STOR(RETR)、PORT(PASV)を並列に処理できないホストがあるため
 						ReleaseMutex(hListAccMutex);
 						if (Pkt->ctrl_skt->IsSSLAttached()) {
-							if (data_socket->AttachSSL(Pkt->ctrl_skt.get(), CancelCheckWork, {}))
+							if (data_socket->AttachSSL(CancelCheckWork))
 								iRetCode = DownloadFile(Pkt, data_socket, CreateMode, CancelCheckWork);
 							else
 								iRetCode = 500;
@@ -1679,7 +1679,7 @@ static int UploadNonPassive(TRANSPACKET *Pkt)
 				// 一部TYPE、STOR(RETR)、PORT(PASV)を並列に処理できないホストがあるため
 				ReleaseMutex(hListAccMutex);
 				if (Pkt->ctrl_skt->IsSSLAttached()) {
-					if (data_socket->AttachSSL(Pkt->ctrl_skt.get(), &Canceled[Pkt->ThreadCount], {}))
+					if (data_socket->AttachSSL(&Canceled[Pkt->ThreadCount]))
 						iRetCode = UploadFile(Pkt, data_socket);
 					else
 						iRetCode = 500;
@@ -1733,7 +1733,7 @@ static int UploadPassive(TRANSPACKET *Pkt)
 	if(iRetCode/100 == FTP_COMPLETE)
 	{
 		if (auto const target = GetAdrsAndPort(Pkt->ctrl_skt, text)) {
-			if (auto [host, port] = *target; data_socket = connectsock(std::move(host), port, IDS_MSGJPN109, &Canceled[Pkt->ThreadCount])) {
+			if (auto [host, port] = *target; data_socket = connectsock(*Pkt->ctrl_skt, std::move(host), port, IDS_MSGJPN109, &Canceled[Pkt->ThreadCount])) {
 				// 変数が未初期化のバグ修正
 				Flg = 1;
 				if(setsockopt(data_socket->handle, IPPROTO_TCP, TCP_NODELAY, (LPSTR)&Flg, sizeof(Flg)) == SOCKET_ERROR)
@@ -1759,7 +1759,7 @@ static int UploadPassive(TRANSPACKET *Pkt)
 					// 一部TYPE、STOR(RETR)、PORT(PASV)を並列に処理できないホストがあるため
 					ReleaseMutex(hListAccMutex);
 					if (Pkt->ctrl_skt->IsSSLAttached()) {
-						if (data_socket->AttachSSL(Pkt->ctrl_skt.get(), &Canceled[Pkt->ThreadCount], {}))
+						if (data_socket->AttachSSL(&Canceled[Pkt->ThreadCount]))
 							iRetCode = UploadFile(Pkt, data_socket);
 						else
 							iRetCode = 500;

--- a/getput.cpp
+++ b/getput.cpp
@@ -556,7 +556,7 @@ static unsigned __stdcall TransferThread(void *Dummy)
 			// セッションあたりの転送量制限対策
 			if (TrnSkt && AskErrorReconnect() == YES && LastError == YES) {
 				ReleaseMutex(hListAccMutex);
-				DoQUIT(TrnSkt->handle, &Canceled[ThreadCount]);
+				DoQUIT(TrnSkt, &Canceled[ThreadCount]);
 				DoClose(TrnSkt->handle);
 				TrnSkt.reset();
 //				WaitForSingleObject(hListAccMutex, INFINITE);
@@ -602,7 +602,7 @@ static unsigned __stdcall TransferThread(void *Dummy)
 					if(timeGetTime() - LastUsed > 60000 || AskConnecting() == NO || ThreadCount >= AskMaxThreadCount())
 					{
 						ReleaseMutex(hListAccMutex);
-						DoQUIT(TrnSkt->handle, &Canceled[ThreadCount]);
+						DoQUIT(TrnSkt, &Canceled[ThreadCount]);
 						DoClose(TrnSkt->handle);
 						TrnSkt.reset();
 //						WaitForSingleObject(hListAccMutex, INFINITE);
@@ -666,8 +666,8 @@ static unsigned __stdcall TransferThread(void *Dummy)
 						if(Pos->Command.starts_with(L"RETR-S"sv))
 						{
 							/* サイズと日付を取得 */
-							DoSIZE(TrnSkt->handle, Pos->Remote, &Pos->Size, &Canceled[Pos->ThreadCount]);
-							DoMDTM(TrnSkt->handle, Pos->Remote, &Pos->Time, &Canceled[Pos->ThreadCount]);
+							DoSIZE(TrnSkt, Pos->Remote, &Pos->Size, &Canceled[Pos->ThreadCount]);
+							DoMDTM(TrnSkt, Pos->Remote, &Pos->Time, &Canceled[Pos->ThreadCount]);
 							Pos->Command = L"RETR "s;
 						}
 
@@ -715,7 +715,7 @@ static unsigned __stdcall TransferThread(void *Dummy)
 					if((SaveTimeStamp == YES) &&
 					   ((Pos->Time.dwLowDateTime != 0) || (Pos->Time.dwHighDateTime != 0)))
 					{
-						DoMFMT(TrnSkt->handle, Pos->Remote, &Pos->Time, &Canceled[Pos->ThreadCount]);
+						DoMFMT(TrnSkt, Pos->Remote, &Pos->Time, &Canceled[Pos->ThreadCount]);
 					}
 				}
 				// 一部TYPE、STOR(RETR)、PORT(PASV)を並列に処理できないホストがあるため

--- a/getput.cpp
+++ b/getput.cpp
@@ -1102,7 +1102,7 @@ static int DownloadNonPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 	std::shared_ptr<SocketContext> listen_socket; // data listen socket
 	int CreateMode;
 
-	if (listen_socket = GetFTPListenSocket(Pkt->ctrl_skt->handle, CancelCheckWork)) {
+	if (listen_socket = GetFTPListenSocket(Pkt->ctrl_skt, CancelCheckWork)) {
 		if(SetDownloadResume(Pkt, Pkt->Mode, Pkt->ExistSize, &CreateMode, CancelCheckWork) == YES)
 		{
 			std::wstring text;
@@ -1110,7 +1110,7 @@ static int DownloadNonPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 			if(iRetCode/100 == FTP_PRELIM)
 			{
 				if (AskHostFireWall() == YES && (FwallType == FWALL_SOCKS4 || FwallType == FWALL_SOCKS5_NOAUTH || FwallType == FWALL_SOCKS5_USER)) {
-					if (!SocksReceiveReply(listen_socket->handle, CancelCheckWork))
+					if (!SocksReceiveReply(listen_socket, CancelCheckWork))
 						data_socket = listen_socket;
 					else {
 						DoClose(listen_socket->handle);
@@ -1626,7 +1626,7 @@ static int UploadNonPassive(TRANSPACKET *Pkt)
 	std::shared_ptr<SocketContext> listen_socket; // data listen socket
 	int Resume;
 
-	if (listen_socket = GetFTPListenSocket(Pkt->ctrl_skt->handle, &Canceled[Pkt->ThreadCount])) {
+	if (listen_socket = GetFTPListenSocket(Pkt->ctrl_skt, &Canceled[Pkt->ThreadCount])) {
 		SetUploadResume(Pkt, Pkt->Mode, Pkt->ExistSize, &Resume);
 		auto cmd = L"APPE "sv;
 		std::wstring extra;
@@ -1647,7 +1647,7 @@ static int UploadNonPassive(TRANSPACKET *Pkt)
 			if(Pkt->Mode == EXIST_UNIQUE)
 				Pkt->Attr = -1;
 			if (AskHostFireWall() == YES && (FwallType == FWALL_SOCKS4 || FwallType == FWALL_SOCKS5_NOAUTH || FwallType == FWALL_SOCKS5_USER)) {
-				if (SocksReceiveReply(listen_socket->handle, &Canceled[Pkt->ThreadCount]))
+				if (SocksReceiveReply(listen_socket, &Canceled[Pkt->ThreadCount]))
 					data_socket = listen_socket;
 				else {
 					DoClose(listen_socket->handle);

--- a/getput.cpp
+++ b/getput.cpp
@@ -1121,7 +1121,7 @@ static int DownloadNonPassive(TRANSPACKET *Pkt, int *CancelCheckWork)
 				} else {
 					sockaddr_storage sa;
 					int salen = sizeof(sockaddr_storage);
-					data_socket = do_accept(listen_socket->handle, reinterpret_cast<sockaddr*>(&sa), &salen);
+					data_socket = listen_socket->Accept(reinterpret_cast<sockaddr*>(&sa), &salen);
 
 					if(shutdown(listen_socket->handle, 1) != 0)
 						WSAError(L"shutdown(listen)"sv);
@@ -1670,7 +1670,7 @@ static int UploadNonPassive(TRANSPACKET *Pkt)
 			} else {
 				sockaddr_storage sa;
 				int salen = sizeof(sockaddr_storage);
-				data_socket = do_accept(listen_socket->handle, reinterpret_cast<sockaddr*>(&sa), &salen);
+				data_socket = listen_socket->Accept(reinterpret_cast<sockaddr*>(&sa), &salen);
 
 				if(shutdown(listen_socket->handle, 1) != 0)
 					WSAError(L"shutdown(listen)"sv);

--- a/main.cpp
+++ b/main.cpp
@@ -1793,7 +1793,7 @@ void DoubleClickProc(int Win, int Mode, int App) {
 						DisableUserOpe();
 						if (CheckPathViolation(MainTransPkt) == NO) {
 							CancelFlg = NO;
-							Sts = DoDownload(AskCmdCtrlSkt(), MainTransPkt, NO, &CancelFlg);
+							Sts = DoDownload(AskCmdCtrlSkt()->handle, MainTransPkt, NO, &CancelFlg);
 							if (MarkAsInternet == YES && IsZoneIDLoaded() == YES)
 								MarkFileAsDownloadedFromInternet(remotePath);
 						}

--- a/main.cpp
+++ b/main.cpp
@@ -1793,7 +1793,7 @@ void DoubleClickProc(int Win, int Mode, int App) {
 						DisableUserOpe();
 						if (CheckPathViolation(MainTransPkt) == NO) {
 							CancelFlg = NO;
-							Sts = DoDownload(AskCmdCtrlSkt()->handle, MainTransPkt, NO, &CancelFlg);
+							Sts = DoDownload(AskCmdCtrlSkt(), MainTransPkt, NO, &CancelFlg);
 							if (MarkAsInternet == YES && IsZoneIDLoaded() == YES)
 								MarkFileAsDownloadedFromInternet(remotePath);
 						}

--- a/remote.cpp
+++ b/remote.cpp
@@ -372,7 +372,7 @@ std::tuple<int, std::wstring> detail::command(std::shared_ptr<SocketContext> cSk
 	}
 	auto native = ConvertTo(cmd, AskHostNameKanji(), AskHostNameKana());
 	native += "\r\n"sv;
-	if (SendData(cSkt->handle, data(native), size_as<int>(native), 0, CancelCheckWork) != FFFTP_SUCCESS)
+	if (SendData(cSkt, data(native), size_as<int>(native), 0, CancelCheckWork) != FFFTP_SUCCESS)
 		return { 429, {} };
 	return ReadReplyMessage(cSkt, CancelCheckWork);
 }
@@ -419,7 +419,7 @@ static std::tuple<int, std::wstring> ReadOneLine(std::shared_ptr<SocketContext> 
 	do {
 		int TimeOutErr;
 		/* LFまでを受信するために、最初はPEEKで受信 */
-		if ((read = do_recv(cSkt->handle, buffer, size_as<int>(buffer), MSG_PEEK, &TimeOutErr, CancelCheckWork)) <= 0) {
+		if ((read = do_recv(cSkt, buffer, size_as<int>(buffer), MSG_PEEK, &TimeOutErr, CancelCheckWork)) <= 0) {
 			if (TimeOutErr == YES) {
 				Notice(IDS_MSGJPN242);
 				read = -2;
@@ -432,7 +432,7 @@ static std::tuple<int, std::wstring> ReadOneLine(std::shared_ptr<SocketContext> 
 		if (auto lf = std::find(buffer, buffer + read, '\n'); lf != buffer + read)
 			read = (int)(lf - buffer + 1);
 		/* 本受信 */
-		if ((read = do_recv(cSkt->handle, buffer, read, 0, &TimeOutErr, CancelCheckWork)) <= 0)
+		if ((read = do_recv(cSkt, buffer, read, 0, &TimeOutErr, CancelCheckWork)) <= 0)
 			break;
 		line.append(buffer, buffer + read);
 	} while (!line.ends_with('\n'));
@@ -481,7 +481,7 @@ int ReadNchar(std::shared_ptr<SocketContext> cSkt, char *Buf, int Size, int *Can
 		Sts = FFFTP_SUCCESS;
 		while(Size > 0)
 		{
-			if((SizeOnce = do_recv(cSkt->handle, Buf, Size, 0, &TimeOutErr, CancelCheckWork)) <= 0)
+			if((SizeOnce = do_recv(cSkt, Buf, Size, 0, &TimeOutErr, CancelCheckWork)) <= 0)
 			{
 				if(TimeOutErr == YES)
 					Notice(IDS_MSGJPN243);

--- a/remote.cpp
+++ b/remote.cpp
@@ -273,7 +273,7 @@ int DoQUOTE(std::shared_ptr<SocketContext> cSkt, std::wstring_view CmdStr, int* 
 // ソケットを閉じる
 void DoClose(std::shared_ptr<SocketContext> Sock) {
 	if (Sock) {
-		do_closesocket(Sock->handle);
+		Sock->Close();
 		Debug(L"Skt={} : Socket closed."sv, Sock->handle);
 	}
 }

--- a/remote.cpp
+++ b/remote.cpp
@@ -270,27 +270,12 @@ int DoQUOTE(SOCKET cSkt, std::wstring_view CmdStr, int* CancelCheckWork) {
 }
 
 
-/*----- ソケットを閉じる ------------------------------------------------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		SOCKET 閉じた後のソケット
-*----------------------------------------------------------------------------*/
-
-SOCKET DoClose(SOCKET Sock)
-{
-	if(Sock != INVALID_SOCKET)
-	{
+// ソケットを閉じる
+void DoClose(SOCKET Sock) {
+	if (Sock != INVALID_SOCKET) {
 		do_closesocket(Sock);
 		Debug(L"Skt={} : Socket closed."sv, Sock);
-		Sock = INVALID_SOCKET;
 	}
-	if(Sock != INVALID_SOCKET)
-		Debug(L"Skt={} : Failed to close socket."sv, Sock);
-
-	return(Sock);
 }
 
 
@@ -466,8 +451,10 @@ static std::tuple<int, std::wstring> ReadOneLine(SOCKET cSkt, int* CancelCheckWo
 		line.append(buffer, buffer + read);
 	} while (!line.ends_with('\n'));
 	if (read <= 0) {
-		if (read == -2 || AskTransferNow() == YES)
-			cSkt = DoClose(cSkt);
+		if (read == -2 || AskTransferNow() == YES) {
+			DoClose(cSkt);
+			cSkt = INVALID_SOCKET;
+		}
 		return { 429, {} };
 	}
 

--- a/remote.cpp
+++ b/remote.cpp
@@ -319,7 +319,7 @@ int DoDirList(std::wstring_view AddOpt, int Num, int* CancelCheckWork) {
 	MainTransPkt.NoTransfer = NO;
 	MainTransPkt.ExistSize = 0;
 	MainTransPkt.hWndTrans = {};
-	auto code = DoDownload(AskCmdCtrlSkt()->handle, MainTransPkt, YES, CancelCheckWork);
+	auto code = DoDownload(AskCmdCtrlSkt(), MainTransPkt, YES, CancelCheckWork);
 	if (code / 100 >= FTP_CONTINUE)
 		Sound::Error.Play();
 	return code / 100;

--- a/socket.cpp
+++ b/socket.cpp
@@ -48,7 +48,6 @@
 struct AsyncSignal {
 	int Event = 0;
 	int Error = 0;
-	std::variant<sockaddr_storage, std::tuple<std::wstring, int>> Target;
 };
 
 
@@ -516,22 +515,6 @@ static void RegisterAsyncTable(SOCKET s) {
 static void UnregisterAsyncTable(SOCKET s) {
 	std::lock_guard lock{ SignalMutex };
 	Signal.erase(s);
-}
-
-
-void SetAsyncTableData(SOCKET s, std::variant<sockaddr_storage, std::tuple<std::wstring, int>> const& target) {
-	std::lock_guard lock{ SignalMutex };
-	if (auto it = Signal.find(s); it != end(Signal))
-		it->second.Target = target;
-}
-
-int GetAsyncTableData(SOCKET s, std::variant<sockaddr_storage, std::tuple<std::wstring, int>>& target) {
-	std::lock_guard lock{ SignalMutex };
-	if (auto it = Signal.find(s); it != end(Signal)) {
-		target = it->second.Target;
-		return YES;
-	}
-	return NO;
 }
 
 

--- a/socket.cpp
+++ b/socket.cpp
@@ -494,12 +494,12 @@ int SocketContext::Connect(const sockaddr* name, int namelen, int* CancelCheckWo
 }
 
 
-int do_listen(SOCKET s, int backlog) {
-	if (WSAAsyncSelect(s, hWndSocket, WM_ASYNC_SOCKET, FD_CLOSE | FD_ACCEPT) != 0) {
+int SocketContext::Listen(int backlog) {
+	if (WSAAsyncSelect(handle, hWndSocket, WM_ASYNC_SOCKET, FD_CLOSE | FD_ACCEPT) != 0) {
 		WSAError(L"do_listen: WSAAsyncSelect()"sv);
 		return SOCKET_ERROR;
 	}
-	if (listen(s, backlog) != 0) {
+	if (listen(handle, backlog) != 0) {
 		WSAError(L"do_listen: listen()"sv);
 		return SOCKET_ERROR;
 	}

--- a/socket.cpp
+++ b/socket.cpp
@@ -49,7 +49,6 @@ struct AsyncSignal {
 	int Event = 0;
 	int Error = 0;
 	std::variant<sockaddr_storage, std::tuple<std::wstring, int>> Target;
-	int MapPort = 0;
 };
 
 
@@ -526,25 +525,10 @@ void SetAsyncTableData(SOCKET s, std::variant<sockaddr_storage, std::tuple<std::
 		it->second.Target = target;
 }
 
-void SetAsyncTableDataMapPort(SOCKET s, int Port) {
-	std::lock_guard lock{ SignalMutex };
-	if (auto it = Signal.find(s); it != end(Signal))
-		it->second.MapPort = Port;
-}
-
 int GetAsyncTableData(SOCKET s, std::variant<sockaddr_storage, std::tuple<std::wstring, int>>& target) {
 	std::lock_guard lock{ SignalMutex };
 	if (auto it = Signal.find(s); it != end(Signal)) {
 		target = it->second.Target;
-		return YES;
-	}
-	return NO;
-}
-
-int GetAsyncTableDataMapPort(SOCKET s, int* Port) {
-	std::lock_guard lock{ SignalMutex };
-	if (auto it = Signal.find(s); it != end(Signal)) {
-		*Port = it->second.MapPort;
 		return YES;
 	}
 	return NO;

--- a/socket.cpp
+++ b/socket.cpp
@@ -229,7 +229,7 @@ auto getCertContext(CtxtHandle& context) {
 }
 
 void ShowCertificate() {
-	if (auto context = getContext(AskCmdCtrlSkt()))
+	if (auto context = getContext(AskCmdCtrlSkt()->handle))
 		if (auto certContext = getCertContext(context->context)) {
 			CRYPTUI_VIEWCERTIFICATE_STRUCTW certViewInfo{ sizeof CRYPTUI_VIEWCERTIFICATE_STRUCTW, 0, CRYPTUI_DISABLE_EDITPROPERTIES | CRYPTUI_DISABLE_ADDTOSTORE, nullptr, certContext.get() };
 			__pragma(warning(suppress:6387)) CryptUIDlgViewCertificateW(&certViewInfo, nullptr);
@@ -396,7 +396,7 @@ BOOL AttachSSL(SOCKET s, SOCKET parent, BOOL* pbAborted, std::wstring_view Serve
 }
 
 bool IsSecureConnection() {
-	auto context = getContext(AskCmdCtrlSkt());
+	auto context = getContext(AskCmdCtrlSkt()->handle);
 	return context && context->secure;
 }
 
@@ -807,7 +807,7 @@ int CheckClosedAndReconnect(void)
 	int Error;
 	int Sts;
 	Sts = FFFTP_SUCCESS;
-	if(AskAsyncDone(AskCmdCtrlSkt(), &Error, FD_CLOSE) == YES)
+	if(AskAsyncDone(AskCmdCtrlSkt()->handle, &Error, FD_CLOSE) == YES)
 	{
 		Sts = ReConnectCmdSkt();
 	}


### PR DESCRIPTION
既存のコードでは生の`SOCKET`ハンドルを扱っているため、処理の構造化も困難となっていた。ソケットオブジェクトを導入し必要な状態を保持することでリファクタリングを行う。
例えば、ソケットの接続先サーバー名を保持する。これにより、Control connectionからData connectionに対して接続先サーバー名を引き継げ、SSLの証明書処理を確実に行えるようになる。

次いで、TLS v1.3対応を行う。具体的には`DecryptMessage()`が返す`SEC_I_RENEGOTIATE`が処理できていなかった。理由は簡単で、ソケットの状態を保持できていなかったから。