### PR TITLE
非同期I/Oを導入する

### DIFF
--- a/common.h
+++ b/common.h
@@ -448,6 +448,7 @@ struct SocketContext {
 	std::vector<char> readPlain;
 	bool sslNeedRenegotiate = false;
 	SECURITY_STATUS sslReadStatus = SEC_E_OK;
+	int recvStatus = WSAEWOULDBLOCK;
 
 	inline SocketContext(SOCKET s, std::wstring originalTarget, std::wstring punyTarget);
 	SocketContext(SocketContext const&) = delete;
@@ -462,14 +463,14 @@ struct SocketContext {
 	constexpr bool IsSSLAttached() {
 		return SecIsValidHandle(&sslContext);
 	}
-	void Decypt();
 	std::vector<char> Encrypt(std::string_view plain);
 	bool GetEvent(int mask);
 	int Connect(const sockaddr* name, int namelen, int* CancelCheckWork);
 	int Listen(int backlog);
-	int RecvInternal(char* buf, int len, int flags);
-	int Recv(char* buf, int len, int flags, int* TimeOutErr, int* CancelCheckWork);
-	void RemoveReceivedData();
+	int FetchAll();
+	std::variant<std::string, int> ReadLine();
+	std::variant<std::vector<char>, int> ReadBytes(int len);
+	void ClearReadBuffer();
 	int Send(const char* buf, int len, int flags, int* CancelCheckWork);
 };
 

--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -2366,7 +2366,7 @@ void AbortRecoveryProc(void)
 			}
 			else {
 				if (auto sc = AskCmdCtrlSkt())
-					sc->RemoveReceivedData();
+					sc->ClearReadBuffer();
 			}
 		}
 	}

--- a/getput.cpp
+++ b/getput.cpp
@@ -650,7 +650,7 @@ static unsigned __stdcall TransferThread(void *Dummy)
 				SendMessageW(hWndTrans, WM_SET_PACKET, 0, (LPARAM)&*Pos);
 
 			// 中断後に受信バッファに応答が残っていると次のコマンドの応答が正しく処理できない
-			TrnSkt->RemoveReceivedData();
+			TrnSkt->ClearReadBuffer();
 
 			/* ダウンロード */
 			if(Pos->Command.starts_with(L"RETR"sv))
@@ -1305,36 +1305,24 @@ static int DownloadFile(TRANSPACKET *Pkt, std::shared_ptr<SocketContext> dSkt, i
 		CodeConverter cc{ Pkt->KanjiCode, Pkt->KanjiCodeDesired, Pkt->KanaCnv != NO };
 
 		/*===== ファイルを受信するループ =====*/
-		std::vector<char> buf(BUFSIZE);
-		int read = 0;
 		while (Pkt->Abort == ABORT_NONE && ForceAbort == NO) {
-			if (int timeout; (read = dSkt->Recv(data(buf), BUFSIZE, 0, &timeout, CancelCheckWork)) <= 0) {
-				if (timeout == YES) {
-					SetErrorMsg(GetString(IDS_MSGJPN094));
-					Notice(IDS_MSGJPN094);
-					if (Pkt->hWndTrans != NULL)
-						ClearAll = YES;
-					if (Pkt->Abort == ABORT_NONE)
-						Pkt->Abort = ABORT_ERROR;
-				} else if (read == SOCKET_ERROR) {
-					if (Pkt->Abort == ABORT_NONE)
-						Pkt->Abort = ABORT_ERROR;
+			auto result = dSkt->ReadBytes(BUFSIZE);
+			if (auto ptr = std::get_if<0>(&result)) {
+				if (auto converted = cc.Convert({ data(*ptr), size(*ptr) }); !os.write(data(converted), size(converted)))
+					Pkt->Abort = ABORT_DISKFULL;
+				Pkt->ExistSize += size_as<LONGLONG>(*ptr);
+				if (Pkt->hWndTrans != NULL)
+					AllTransSizeNow[Pkt->ThreadCount] += size_as<LONGLONG>(*ptr);
+				else {
+					/* 転送ダイアログを出さない時の経過表示 */
+					DispDownloadSize(Pkt->ExistSize);
 				}
+			} else if (auto status = std::get<1>(result); status != WSAEWOULDBLOCK) {
+				if (status != 0 && Pkt->Abort == ABORT_NONE)
+					Pkt->Abort = ABORT_ERROR;
 				break;
 			}
-
-			if (auto converted = cc.Convert({ data(buf), (size_t)read }); !os.write(data(converted), size(converted)))
-				Pkt->Abort = ABORT_DISKFULL;
-
-			Pkt->ExistSize += read;
-			if (Pkt->hWndTrans != NULL)
-				AllTransSizeNow[Pkt->ThreadCount] += read;
-			else {
-				/* 転送ダイアログを出さない時の経過表示 */
-				DispDownloadSize(Pkt->ExistSize);
-			}
-
-			if (BackgrndMessageProc() == YES)
+			if (BackgrndMessageProc() == YES || *CancelCheckWork == YES)
 				ForceAbort = YES;
 		}
 
@@ -1347,9 +1335,6 @@ static int DownloadFile(TRANSPACKET *Pkt, std::shared_ptr<SocketContext> dSkt, i
 			/* 転送ダイアログを出さない時の経過表示を消す */
 			DispDownloadSize(-1);
 		}
-
-		if (read == SOCKET_ERROR)
-			WSAError(L"recv()"sv);
 	} else {
 		SetErrorMsg(std::vformat(GetString(IDS_MSGJPN095), std::make_wformat_args(Pkt->Local.native())));
 		Notice(IDS_MSGJPN095, Pkt->Local.native());

--- a/remote.cpp
+++ b/remote.cpp
@@ -415,32 +415,18 @@ static std::tuple<int, std::wstring> ReadOneLine(std::shared_ptr<SocketContext> 
 		return { 0, {} };
 
 	std::string line;
-	int read;
-	char buffer[1024];
-	do {
-		int TimeOutErr;
-		/* LFまでを受信するために、最初はPEEKで受信 */
-		if ((read = cSkt->Recv(buffer, size_as<int>(buffer), MSG_PEEK, &TimeOutErr, CancelCheckWork)) <= 0) {
-			if (TimeOutErr == YES) {
-				Notice(IDS_MSGJPN242);
-				read = -2;
-			} else if (read == SOCKET_ERROR)
-				read = -1;
+	for (;;) {
+		auto result = cSkt->ReadLine();
+		if (auto ptr = std::get_if<0>(&result)) {
+			line = std::move(*ptr);
 			break;
 		}
-		/* LFを探して、あったらそこまでの長さをセット */
-		assert(std::find(buffer, buffer + read, '\0') == buffer + read);
-		if (auto lf = std::find(buffer, buffer + read, '\n'); lf != buffer + read)
-			read = (int)(lf - buffer + 1);
-		/* 本受信 */
-		if ((read = cSkt->Recv(buffer, read, 0, &TimeOutErr, CancelCheckWork)) <= 0)
-			break;
-		line.append(buffer, buffer + read);
-	} while (!line.ends_with('\n'));
-	if (read <= 0) {
-		if (read == -2 || AskTransferNow() == YES)
-			DoClose(cSkt);
-		return { 429, {} };
+		if (std::get<1>(result) != WSAEWOULDBLOCK)
+			return { 429, {} };
+		// TODO: timeout
+		Sleep(1);
+		if (BackgrndMessageProc() == YES || *CancelCheckWork == YES)
+			return { 429, {} };
 	}
 
 	int replyCode = 0;
@@ -467,36 +453,26 @@ static std::tuple<int, std::wstring> ReadOneLine(std::shared_ptr<SocketContext> 
 *			FFFTP_SUCCESS/FFFTP_FAIL
 *----------------------------------------------------------------------------*/
 
-int ReadNchar(std::shared_ptr<SocketContext> cSkt, char *Buf, int Size, int *CancelCheckWork)
-{
-//	struct timeval Tout;
-//	struct timeval *ToutPtr;
-//	fd_set ReadFds;
-//	int i;
-	int SizeOnce;
-	int Sts;
-	int TimeOutErr;
-
-	Sts = FFFTP_FAIL;
+int ReadNchar(std::shared_ptr<SocketContext> cSkt, char* Buf, int Size, int* CancelCheckWork) {
 	if (cSkt) {
-		Sts = FFFTP_SUCCESS;
-		while(Size > 0)
-		{
-			if((SizeOnce = cSkt->Recv(Buf, Size, 0, &TimeOutErr, CancelCheckWork)) <= 0)
-			{
-				if(TimeOutErr == YES)
-					Notice(IDS_MSGJPN243);
-				Sts = FFFTP_FAIL;
+		for (;;) {
+			auto result = cSkt->ReadBytes(Size);
+			if (auto ptr = std::get_if<0>(&result)) {
+				std::ranges::copy(*ptr, Buf);
+				Buf += size(*ptr);
+				Size -= size_as<int>(*ptr);
+				if (Size == 0)
+					return FFFTP_SUCCESS;
+			} else if (std::get<1>(result) != WSAEWOULDBLOCK) {
 				break;
+			} else {
+				// TODO: timeout
+				Sleep(1);
+				if (BackgrndMessageProc() == YES || *CancelCheckWork == YES)
+					break;
 			}
-
-			Buf += SizeOnce;
-			Size -= SizeOnce;
 		}
 	}
-
-	if(Sts == FFFTP_FAIL)
-		Notice(IDS_MSGJPN244);
-
-	return(Sts);
+	Notice(IDS_MSGJPN244);
+	return FFFTP_FAIL;
 }

--- a/socket.cpp
+++ b/socket.cpp
@@ -49,65 +49,6 @@ static constexpr unsigned long contextReq = ISC_REQ_STREAM | ISC_REQ_SEQUENCE_DE
 static CredHandle credential = CreateInvalidateHandle<CredHandle>();
 
 
-void SocketContext::Decypt() {
-	while (!empty(readRaw)) {
-		if (sslNeedRenegotiate) {
-			SecBuffer inBuffer[]{ { size_as<unsigned long>(readRaw), SECBUFFER_TOKEN, data(readRaw) }, { 0, SECBUFFER_EMPTY, nullptr } };
-			SecBuffer outBuffer[]{ { 0, SECBUFFER_EMPTY, nullptr }, { 0, SECBUFFER_EMPTY, nullptr } };
-			SecBufferDesc inDesc{ SECBUFFER_VERSION, size_as<unsigned long>(inBuffer), inBuffer };
-			SecBufferDesc outDesc{ SECBUFFER_VERSION, size_as<unsigned long>(outBuffer), outBuffer };
-			unsigned long attr = 0;
-			sslReadStatus = InitializeSecurityContextW(&credential, &sslContext, const_cast<SEC_WCHAR*>(punyTarget.c_str()), contextReq, 0, 0, &inDesc, 0, nullptr, &outDesc, &attr, nullptr);
-			_RPTWN(_CRT_WARN, L"Decypt(): InitializeSecurityContextW(): in=%d, 0x%08X, in: %d/%d/%p, %d/%d/%p, out: %d/%d/%p, %d/%d/%p, attr=%X.\n", size_as<int>(readRaw), sslReadStatus,
-				inBuffer[0].BufferType, inBuffer[0].cbBuffer, inBuffer[0].pvBuffer, inBuffer[1].BufferType, inBuffer[1].cbBuffer, inBuffer[1].pvBuffer,
-				outBuffer[0].BufferType, outBuffer[0].cbBuffer, outBuffer[0].pvBuffer, outBuffer[1].BufferType, outBuffer[1].cbBuffer, outBuffer[1].pvBuffer,
-				attr
-			);
-			if (outBuffer[0].BufferType == SECBUFFER_TOKEN && outBuffer[0].cbBuffer != 0) {
-				auto written = send(handle, reinterpret_cast<const char*>(outBuffer[0].pvBuffer), outBuffer[0].cbBuffer, 0);
-				_RPTWN(_CRT_WARN, L"Decypt(): send: %d bytes.\n", written);
-				assert(written == outBuffer[0].cbBuffer);
-				FreeContextBuffer(outBuffer[0].pvBuffer);
-			}
-			if (sslReadStatus == SEC_E_OK || sslReadStatus == SEC_I_CONTINUE_NEEDED) {
-				readRaw.erase(begin(readRaw), end(readRaw) - (inBuffer[1].BufferType == SECBUFFER_EXTRA ? inBuffer[1].cbBuffer : 0));
-				if (sslReadStatus == SEC_E_OK)
-					sslNeedRenegotiate = false;
-			} else {
-				if (sslReadStatus != SEC_E_INCOMPLETE_MESSAGE)
-					Error(L"Decypt(): InitializeSecurityContextW()"sv, sslReadStatus);
-				return;
-			}
-		} else {
-			SecBuffer buffer[]{
-				{ size_as<unsigned long>(readRaw), SECBUFFER_DATA, data(readRaw) },
-				{ 0, SECBUFFER_EMPTY, nullptr },
-				{ 0, SECBUFFER_EMPTY, nullptr },
-				{ 0, SECBUFFER_EMPTY, nullptr },
-			};
-			SecBufferDesc desc{ SECBUFFER_VERSION, size_as<unsigned long>(buffer), buffer };
-			sslReadStatus = DecryptMessage(&sslContext, &desc, 0, nullptr);
-			_RPTWN(_CRT_WARN, L"DecryptMessage(): in=%d, %08X, %d/%d/%p, %d/%d/%p, %d/%d/%p, %d/%d/%p.\n", size_as<int>(readRaw), sslReadStatus,
-				buffer[0].BufferType, buffer[0].cbBuffer, buffer[0].pvBuffer, buffer[1].BufferType, buffer[1].cbBuffer, buffer[1].pvBuffer,
-				buffer[2].BufferType, buffer[2].cbBuffer, buffer[2].pvBuffer, buffer[3].BufferType, buffer[3].cbBuffer, buffer[3].pvBuffer
-			);
-			if (sslReadStatus == SEC_E_OK) {
-				assert(buffer[0].BufferType == SECBUFFER_STREAM_HEADER && buffer[1].BufferType == SECBUFFER_DATA && buffer[2].BufferType == SECBUFFER_STREAM_TRAILER);
-				readPlain.insert(end(readPlain), reinterpret_cast<const char*>(buffer[1].pvBuffer), reinterpret_cast<const char*>(buffer[1].pvBuffer) + buffer[1].cbBuffer);
-				readRaw.erase(begin(readRaw), end(readRaw) - (buffer[3].BufferType == SECBUFFER_EXTRA ? buffer[3].cbBuffer : 0));
-			} else if (sslReadStatus == SEC_I_RENEGOTIATE) {
-				assert(buffer[0].BufferType == SECBUFFER_STREAM_HEADER && buffer[1].BufferType == SECBUFFER_DATA && buffer[1].cbBuffer == 0 && buffer[2].BufferType == SECBUFFER_STREAM_TRAILER && buffer[3].BufferType == SECBUFFER_EXTRA);
-				readRaw.erase(begin(readRaw), end(readRaw) - buffer[3].cbBuffer);
-				sslNeedRenegotiate = true;
-			} else {
-				if (sslReadStatus != SEC_E_INCOMPLETE_MESSAGE)
-					Error(L"Decypt(): DecryptMessage()"sv, sslReadStatus);
-				return;
-			}
-		}
-	}
-}
-
 std::vector<char> SocketContext::Encrypt(std::string_view plain) {
 	std::vector<char> result;
 	while (!empty(plain)) {
@@ -275,59 +216,37 @@ static CertResult ConfirmSSLCertificate(CtxtHandle& context, wchar_t* serverName
 // SSLセッションを開始
 BOOL SocketContext::AttachSSL(BOOL* pbAborted) {
 	assert(SecIsValidHandle(&credential));
-	auto first = true;
-	SECURITY_STATUS ss = SEC_I_CONTINUE_NEEDED;
-	do {
-		SecBuffer inBuffer[]{ { 0, SECBUFFER_EMPTY, nullptr }, { 0, SECBUFFER_EMPTY, nullptr } };
-		SecBuffer outBuffer[]{ { 0, SECBUFFER_EMPTY, nullptr }, { 0, SECBUFFER_EMPTY, nullptr } };
-		SecBufferDesc inDesc{ SECBUFFER_VERSION, size_as<unsigned long>(inBuffer), inBuffer };
-		SecBufferDesc outDesc{ SECBUFFER_VERSION, size_as<unsigned long>(outBuffer), outBuffer };
-		unsigned long attr = 0;
-		if (first) {
-			first = false;
-			__pragma(warning(suppress:6001)) ss = InitializeSecurityContextW(&credential, nullptr, const_cast<SEC_WCHAR*>(punyTarget.c_str()), contextReq, 0, 0, nullptr, 0, &sslContext, &outDesc, &attr, nullptr);
-		} else {
-			char buffer[8192];
-			if (auto read = recv(handle, buffer, size_as<int>(buffer), 0); read == 0) {
-				Debug(L"AttachSSL(): recv: connection closed."sv);
-				return FALSE;
-			} else if (0 < read) {
-				_RPTWN(_CRT_WARN, L"AttachSSL recv: %d bytes.\n", read);
-				readRaw.insert(end(readRaw), buffer, buffer + read);
-			} else if (auto lastError = WSAGetLastError(); lastError != WSAEWOULDBLOCK) {
-				Error(L"AttachSSL(): recv()"sv, lastError);
-				return FALSE;
-			}
-			inBuffer[0] = { size_as<unsigned long>(readRaw), SECBUFFER_TOKEN, data(readRaw) };
-			ss = InitializeSecurityContextW(&credential, &sslContext, const_cast<SEC_WCHAR*>(punyTarget.c_str()), contextReq, 0, 0, &inDesc, 0, nullptr, &outDesc, &attr, nullptr);
-		}
-		_RPTWN(_CRT_WARN, L"AttachSSL(): InitializeSecurityContextW(): in=%d, 0x%08X, in: %d/%d/%p, %d/%d/%p, out: %d/%d/%p, %d/%d/%p, attr=%X.\n", size_as<int>(readRaw), ss,
-			inBuffer[0].BufferType, inBuffer[0].cbBuffer, inBuffer[0].pvBuffer, inBuffer[1].BufferType, inBuffer[1].cbBuffer, inBuffer[1].pvBuffer,
-			outBuffer[0].BufferType, outBuffer[0].cbBuffer, outBuffer[0].pvBuffer, outBuffer[1].BufferType, outBuffer[1].cbBuffer, outBuffer[1].pvBuffer,
-			attr
-		);
-		if (FAILED(ss) && ss != SEC_E_INCOMPLETE_MESSAGE) {
-			Error(L"AttachSSL(): InitializeSecurityContext()"sv, ss);
-			return FALSE;
-		}
-		if (outBuffer[0].BufferType == SECBUFFER_TOKEN && outBuffer[0].cbBuffer != 0) {
-			auto written = send(handle, reinterpret_cast<const char*>(outBuffer[0].pvBuffer), outBuffer[0].cbBuffer, 0);
-			assert(written == outBuffer[0].cbBuffer);
-			_RPTWN(_CRT_WARN, L"AttachSSL(): send: %d bytes.\n", written);
-			FreeContextBuffer(outBuffer[0].pvBuffer);
-		}
-		if (ss == SEC_E_INCOMPLETE_MESSAGE)
-			ss = SEC_I_CONTINUE_NEEDED;
-		else if (inBuffer[1].BufferType == SECBUFFER_EXTRA)
-			// inBuffer[1].pvBufferはnullptrの場合があるためinBuffer[1].cbBufferのみを使用する
-			readRaw.erase(begin(readRaw), end(readRaw) - inBuffer[1].cbBuffer);
-		else
-			readRaw.clear();
-		Sleep(0);
-	} while (ss == SEC_I_CONTINUE_NEEDED);
 
-	if (ss = QueryContextAttributesW(&sslContext, SECPKG_ATTR_STREAM_SIZES, &sslStreamSizes); ss != SEC_E_OK) {
-		Error(L"AttachSSL(): QueryContextAttributes(SECPKG_ATTR_STREAM_SIZES)"sv, ss);
+	SecBuffer outBuffer[]{ { 0, SECBUFFER_EMPTY, nullptr }, { 0, SECBUFFER_EMPTY, nullptr } };
+	SecBufferDesc outDesc{ SECBUFFER_VERSION, size_as<unsigned long>(outBuffer), outBuffer };
+	unsigned long attr = 0;
+	sslReadStatus = InitializeSecurityContextW(&credential, nullptr, const_cast<SEC_WCHAR*>(punyTarget.c_str()), contextReq, 0, 0, nullptr, 0, &sslContext, &outDesc, &attr, nullptr);
+	_RPTWN(_CRT_WARN, L"InitializeSecurityContextW(): in=%d, %08X, out: %d/%d/%p, %d/%d/%p, attr=%X.\n", size_as<int>(readRaw), sslReadStatus,
+		outBuffer[0].BufferType, outBuffer[0].cbBuffer, outBuffer[0].pvBuffer, outBuffer[1].BufferType, outBuffer[1].cbBuffer, outBuffer[1].pvBuffer,
+		attr
+	);
+	if (sslReadStatus != SEC_I_CONTINUE_NEEDED)
+		return FALSE;
+	assert(outBuffer[0].BufferType == SECBUFFER_TOKEN && outBuffer[0].cbBuffer != 0 && outBuffer[0].pvBuffer != nullptr);
+	auto written = send(handle, reinterpret_cast<const char*>(outBuffer[0].pvBuffer), outBuffer[0].cbBuffer, 0);
+	assert(written == outBuffer[0].cbBuffer);
+	_RPTWN(_CRT_WARN, L"send: %d bytes.\n", written);
+	__pragma(warning(suppress:6387)) FreeContextBuffer(outBuffer[0].pvBuffer);
+
+	sslNeedRenegotiate = true;
+
+	for (;;) {
+		FetchAll();
+		if (sslReadStatus == SEC_E_OK)
+			break;
+		if (sslReadStatus == SEC_E_INCOMPLETE_MESSAGE || sslReadStatus == SEC_I_CONTINUE_NEEDED)
+			Sleep(0);
+		else
+			return FALSE;
+	}
+
+	if ((sslReadStatus = QueryContextAttributesW(&sslContext, SECPKG_ATTR_STREAM_SIZES, &sslStreamSizes)) != SEC_E_OK) {
+		Error(L"QueryContextAttributes(SECPKG_ATTR_STREAM_SIZES)"sv, sslReadStatus);
 		return FALSE;
 	}
 
@@ -341,64 +260,13 @@ BOOL SocketContext::AttachSSL(BOOL* pbAborted) {
 	default:
 		return FALSE;
 	}
-	if (!empty(readRaw))
-		Decypt();
 	_RPTW0(_CRT_WARN, L"AttachSSL(): success.\n");
 	return TRUE;
 }
 
 bool IsSecureConnection() {
-	if (auto const& sc = AskCmdCtrlSkt(); sc && sc->IsSSLAttached())
-		return sc->sslSecure;
-	return false;
-}
-
-
-int SocketContext::RecvInternal(char* buf, int len, int flags) {
-	assert(flags == 0 || flags == MSG_PEEK);
-	if (!IsSSLAttached())
-		return recv(handle, buf, len, flags);
-
-	if (empty(readPlain) && sslReadStatus != SEC_I_CONTEXT_EXPIRED) {
-		auto offset = size_as<int>(readRaw);
-		readRaw.resize((size_t)sslStreamSizes.cbHeader + sslStreamSizes.cbMaximumMessage + sslStreamSizes.cbTrailer);
-		auto read = recv(handle, data(readRaw) + offset, size_as<int>(readRaw) - offset, 0);
-		if (read <= 0) {
-			readRaw.resize(offset);
-#ifdef _DEBUG
-			if (read == 0)
-				Debug(L"FTPS_recv: recv(): connection closed."sv);
-			else if (auto lastError = WSAGetLastError(); lastError != WSAEWOULDBLOCK)
-				Error(L"FTPS_recv: recv()"sv, lastError);
-#endif
-			return read;
-		}
-		_RPTWN(_CRT_WARN, L"FTPS_recv recv: %d bytes.\n", read);
-		readRaw.resize((size_t)offset + read);
-		Decypt();
-	}
-
-	if (empty(readPlain))
-		switch (sslReadStatus) {
-		case SEC_I_CONTEXT_EXPIRED:
-			return 0;
-		case SEC_E_OK:
-		case SEC_I_CONTINUE_NEEDED:
-		case SEC_E_INCOMPLETE_MESSAGE:
-			// recvできたデータが少なすぎてフレームの解析・デコードができず、復号データが得られないというエラー。
-			// ブロッキングが発生するというエラーに書き換える。
-			WSASetLastError(WSAEWOULDBLOCK);
-			return SOCKET_ERROR;
-		default:
-			_RPTWN(_CRT_WARN, L"FTPS_recv readStatus: %08X.\n", sslReadStatus);
-			return SOCKET_ERROR;
-		}
-	len = std::min(len, size_as<int>(readPlain));
-	std::copy_n(begin(readPlain), len, buf);
-	if ((flags & MSG_PEEK) == 0)
-		readPlain.erase(begin(readPlain), begin(readPlain) + len);
-	_RPTWN(_CRT_WARN, L"FTPS_recv read: %d bytes.\n", len);
-	return len;
+	auto const& sc = AskCmdCtrlSkt();
+	return sc && sc->IsSSLAttached() && sc->sslSecure;
 }
 
 
@@ -553,28 +421,134 @@ std::shared_ptr<SocketContext> SocketContext::Accept(_Out_writes_bytes_opt_(*add
 }
 
 
-int SocketContext::Recv(char* buf, int len, int flags, int* TimeOutErr, int* CancelCheckWork) {
-	if (*CancelCheckWork != NO)
-		return SOCKET_ERROR;
-	auto endTime = TimeOut != 0 ? std::make_optional(std::chrono::steady_clock::now() + std::chrono::seconds(TimeOut)) : std::nullopt;
-	*TimeOutErr = NO;
-	for (;;) {
-		if (auto read = RecvInternal(buf, len, flags); read != SOCKET_ERROR)
-			return read;
-		if (auto lastError = WSAGetLastError(); lastError != WSAEWOULDBLOCK)
-			return SOCKET_ERROR;
-		Sleep(1);
-		if (BackgrndMessageProc() == YES)
-			return SOCKET_ERROR;
-		if (endTime && *endTime < std::chrono::steady_clock::now()) {
-			Debug(L"do_recv timed out."sv);
-			*TimeOutErr = YES;
-			*CancelCheckWork = YES;
-			return SOCKET_ERROR;
+// ノンブロッキングIOで読み込めるだけ読み込む。読み込み後のステータスを返す。
+//   0 .. これ以上読み込めない。
+//   WSAEWOULDBLOCK .. 受信待ち。
+//   other .. エラー。
+int SocketContext::FetchAll() {
+	static int recvlen = 8192;
+	if (recvStatus == WSAEWOULDBLOCK) {
+		for (;;) {
+			auto offset = size_as<int>(readRaw);
+			readRaw.resize((size_t)offset + recvlen);
+			readRaw.resize(readRaw.capacity());
+			auto len = recv(handle, data(readRaw) + offset, size_as<int>(readRaw) - offset, 0);
+			if (len <= 0)
+				recvStatus = len == 0 ? 0 : WSAGetLastError();
+			_RPTWN(_CRT_WARN, L"recv(): %d.\n", 0 <= len ? len : recvStatus);
+			readRaw.resize((size_t)offset + (len <= 0 ? 0 : len));
+			if (len == 0)
+				break;
+			if (len < 0) {
+				if (recvStatus != WSAEWOULDBLOCK)
+					Error(L"recv()", recvStatus);
+				break;
+			}
+			if (recvlen <= len)
+				recvlen *= 2;
 		}
-		if (*CancelCheckWork == YES)
-			return SOCKET_ERROR;
 	}
+	if (!IsSSLAttached()) {
+		readPlain.insert(end(readPlain), begin(readRaw), end(readRaw));
+		readRaw.clear();
+	} else {
+		while (!empty(readRaw)) {
+			if (sslNeedRenegotiate) {
+				SecBuffer inBuffer[]{ { size_as<unsigned long>(readRaw), SECBUFFER_TOKEN, data(readRaw) }, { 0, SECBUFFER_EMPTY, nullptr } };
+				SecBuffer outBuffer[]{ { 0, SECBUFFER_EMPTY, nullptr }, { 0, SECBUFFER_EMPTY, nullptr } };
+				SecBufferDesc inDesc{ SECBUFFER_VERSION, size_as<unsigned long>(inBuffer), inBuffer };
+				SecBufferDesc outDesc{ SECBUFFER_VERSION, size_as<unsigned long>(outBuffer), outBuffer };
+				unsigned long attr = 0;
+				sslReadStatus = InitializeSecurityContextW(&credential, &sslContext, const_cast<SEC_WCHAR*>(punyTarget.c_str()), contextReq, 0, 0, &inDesc, 0, nullptr, &outDesc, &attr, nullptr);
+				_RPTWN(_CRT_WARN, L"InitializeSecurityContextW(): in=%d, %08X, in: %d/%d/%p, %d/%d/%p, out: %d/%d/%p, %d/%d/%p, attr=%X.\n", size_as<int>(readRaw), sslReadStatus,
+					inBuffer[0].BufferType, inBuffer[0].cbBuffer, inBuffer[0].pvBuffer, inBuffer[1].BufferType, inBuffer[1].cbBuffer, inBuffer[1].pvBuffer,
+					outBuffer[0].BufferType, outBuffer[0].cbBuffer, outBuffer[0].pvBuffer, outBuffer[1].BufferType, outBuffer[1].cbBuffer, outBuffer[1].pvBuffer,
+					attr
+				);
+				if (sslReadStatus == SEC_E_OK || sslReadStatus == SEC_I_CONTINUE_NEEDED) {
+					if (outBuffer[0].BufferType == SECBUFFER_TOKEN && outBuffer[0].cbBuffer != 0) {
+						// TODO: 送信バッファが埋まっている場合に失敗する
+						auto written = send(handle, reinterpret_cast<const char*>(outBuffer[0].pvBuffer), outBuffer[0].cbBuffer, 0);
+						_RPTWN(_CRT_WARN, L"send(): %d.\n", written);
+						assert(written == outBuffer[0].cbBuffer);
+						FreeContextBuffer(outBuffer[0].pvBuffer);
+					}
+					readRaw.erase(begin(readRaw), end(readRaw) - (inBuffer[1].BufferType == SECBUFFER_EXTRA ? inBuffer[1].cbBuffer : 0));
+					if (sslReadStatus == SEC_E_OK)
+						sslNeedRenegotiate = false;
+				} else if (sslReadStatus == SEC_E_INCOMPLETE_MESSAGE) {
+					break;
+				} else {
+					Error(L"InitializeSecurityContextW()"sv, sslReadStatus);
+					return sslReadStatus;
+				}
+			} else {
+				SecBuffer buffer[]{
+					{ size_as<unsigned long>(readRaw), SECBUFFER_DATA, data(readRaw) },
+					{ 0, SECBUFFER_EMPTY, nullptr },
+					{ 0, SECBUFFER_EMPTY, nullptr },
+					{ 0, SECBUFFER_EMPTY, nullptr },
+				};
+				SecBufferDesc desc{ SECBUFFER_VERSION, size_as<unsigned long>(buffer), buffer };
+				sslReadStatus = DecryptMessage(&sslContext, &desc, 0, nullptr);
+				_RPTWN(_CRT_WARN, L"DecryptMessage(): in=%d, %08X, %d/%d/%p, %d/%d/%p, %d/%d/%p, %d/%d/%p.\n", size_as<int>(readRaw), sslReadStatus,
+					buffer[0].BufferType, buffer[0].cbBuffer, buffer[0].pvBuffer, buffer[1].BufferType, buffer[1].cbBuffer, buffer[1].pvBuffer,
+					buffer[2].BufferType, buffer[2].cbBuffer, buffer[2].pvBuffer, buffer[3].BufferType, buffer[3].cbBuffer, buffer[3].pvBuffer
+				);
+				if (sslReadStatus == SEC_E_OK) {
+					assert(buffer[0].BufferType == SECBUFFER_STREAM_HEADER && buffer[1].BufferType == SECBUFFER_DATA && buffer[2].BufferType == SECBUFFER_STREAM_TRAILER);
+					readPlain.insert(end(readPlain), reinterpret_cast<const char*>(buffer[1].pvBuffer), reinterpret_cast<const char*>(buffer[1].pvBuffer) + buffer[1].cbBuffer);
+					readRaw.erase(begin(readRaw), end(readRaw) - (buffer[3].BufferType == SECBUFFER_EXTRA ? buffer[3].cbBuffer : 0));
+				} else if(sslReadStatus == SEC_I_CONTEXT_EXPIRED){
+					assert(buffer[0].BufferType == SECBUFFER_DATA && buffer[0].cbBuffer == size_as<unsigned long>(readRaw));
+					readRaw.clear();
+					return 0;
+				} else if (sslReadStatus == SEC_E_INCOMPLETE_MESSAGE) {
+					break;
+				} else if (sslReadStatus == SEC_I_RENEGOTIATE) {
+					assert(buffer[0].BufferType == SECBUFFER_STREAM_HEADER && buffer[1].BufferType == SECBUFFER_DATA && buffer[1].cbBuffer == 0 && buffer[2].BufferType == SECBUFFER_STREAM_TRAILER && buffer[3].BufferType == SECBUFFER_EXTRA);
+					readRaw.erase(begin(readRaw), end(readRaw) - buffer[3].cbBuffer);
+					sslNeedRenegotiate = true;
+				} else {
+					Error(L"DecryptMessage()"sv, sslReadStatus);
+					return sslReadStatus;
+				}
+			}
+		}
+	}
+	return recvStatus;
+}
+
+
+std::variant<std::string, int> SocketContext::ReadLine() {
+	auto canRead = FetchAll();
+	if (auto it = std::find(begin(readPlain), end(readPlain), '\n'); it != end(readPlain)) {
+		++it;
+		std::string result(begin(readPlain), it);
+		readPlain.erase(begin(readPlain), it);
+		return std::move(result);
+	}
+	return canRead;
+}
+
+
+std::variant<std::vector<char>, int> SocketContext::ReadBytes(int len) {
+	auto canRead = FetchAll();
+	if (!empty(readPlain)) {
+		if (size_as<int>(readPlain) < len)
+			len = size_as<int>(readPlain);
+		std::vector<char> result(begin(readPlain), begin(readPlain) + len);
+		readPlain.erase(begin(readPlain), begin(readPlain) + len);
+		return std::move(result);
+	}
+	return canRead;
+}
+
+
+void SocketContext::ClearReadBuffer() {
+	FetchAll();
+	assert(empty(readRaw));
+	readPlain.clear();
 }
 
 
@@ -618,14 +592,6 @@ int SocketContext::Send(const char* buf, int len, int flags, int* CancelCheckWor
 		}
 	} while (!empty(buffer));
 	return FFFTP_SUCCESS;
-}
-
-
-void SocketContext::RemoveReceivedData() {
-	char buf[1024];
-	int len;
-	while ((len = RecvInternal(buf, sizeof(buf), MSG_PEEK)) > 0)
-		RecvInternal(buf, len, 0);
 }
 
 


### PR DESCRIPTION
#12 の前段として、Alertable I/Oによる非同期を導入する。Alertable I/Oの場合、同一スレッド内のAPC queueで完了コールバックが呼ばれる。現在、UIスレッドと密結合しているため、この方が取り回ししやすい。
