### PR TITLE
ソケット周りの改善

### DIFF
--- a/common.h
+++ b/common.h
@@ -460,7 +460,7 @@ struct SocketContext : public WSAOVERLAPPED {
 	}
 	static std::shared_ptr<SocketContext> Create(int af, std::variant<std::wstring_view, std::reference_wrapper<const SocketContext>> originalTarget);
 	std::shared_ptr<SocketContext> Accept(_Out_writes_bytes_opt_(*addrlen) struct sockaddr* addr, _Inout_opt_ int* addrlen);
-	int Close();
+	void Close();
 	BOOL AttachSSL(BOOL* pbAborted);
 	constexpr bool IsSSLAttached() {
 		return SecIsValidHandle(&sslContext);

--- a/common.h
+++ b/common.h
@@ -40,7 +40,6 @@
 #include <chrono>
 #include <filesystem>
 #include <format>
-#include <forward_list>
 #include <fstream>
 #include <future>
 #include <iterator>
@@ -48,6 +47,7 @@
 #include <mutex>
 #include <numeric>
 #include <optional>
+#include <ranges>
 #include <span>
 #include <sstream>
 #include <string>
@@ -973,13 +973,10 @@ int MakeTransferThread(void);
 void CloseTransferThread(void);
 // 同時接続対応
 void AbortAllTransfer();
-int AddTmpTransFileList(TRANSPACKET const& item, std::forward_list<TRANSPACKET>& list);
-int RemoveTmpTransFileListItem(std::forward_list<TRANSPACKET>& list, int Num);
-
 void AddTransFileList(TRANSPACKET *Pkt);
 // バグ対策
 void AddNullTransFileList();
-void AppendTransFileList(std::forward_list<TRANSPACKET>&& list);
+void AppendTransFileList(std::vector<TRANSPACKET>&& list);
 void KeepTransferDialog(int Sw);
 int AskTransferNow(void);
 int AskTransferFileNum(void);

--- a/common.h
+++ b/common.h
@@ -479,7 +479,7 @@ struct SocketContext : public WSAOVERLAPPED {
 		std::span span{ reinterpret_cast<char*>(&data), sizeof data };
 		return ReadSpan(span, CancelCheckWork);
 	}
-	std::variant<std::vector<char>, int> ReadAll();
+	int ReadAll(int* CancelCheckWork, std::function<bool(std::vector<char> const&)> callback);
 	void ClearReadBuffer();
 	int Send(const char* buf, int len, int flags, int* CancelCheckWork);
 };

--- a/filelist.cpp
+++ b/filelist.cpp
@@ -2148,7 +2148,7 @@ static bool MakeLocalTree(fs::path const& path, std::vector<FILELIST>& Base) {
 *----------------------------------------------------------------------------*/
 
 static void AddFileList(FILELIST const& Pkt, std::vector<FILELIST>& Base) {
-	Debug(L"FileList: NODE={}: {}."sv, Pkt.Node, Pkt.Name);
+	Debug(L"FileList: NODE={}: {}."sv, (unsigned char)Pkt.Node, Pkt.Name);
 	/* リストの重複を取り除く */
 	if (std::ranges::any_of(Base, [&Pkt](auto const& f) { return Pkt.Name == f.Name; })) {
 		Debug(L" --> Duplicate!!"sv);

--- a/getput.cpp
+++ b/getput.cpp
@@ -1365,7 +1365,7 @@ static int DownloadFile(TRANSPACKET *Pkt, std::shared_ptr<SocketContext> dSkt, i
 		Command(Pkt->ctrl_skt, CancelCheckWork, L"ABOR"sv);
 	}
 
-	auto [code, text] = ReadReplyMessage(Pkt->ctrl_skt, CancelCheckWork);
+	auto [code, text] = Pkt->ctrl_skt->ReadReply(CancelCheckWork);
 	if (Pkt->Abort == ABORT_DISKFULL) {
 		SetErrorMsg(GetString(IDS_MSGJPN096));
 		Notice(IDS_MSGJPN096);
@@ -1875,7 +1875,7 @@ static int UploadFile(TRANSPACKET *Pkt, std::shared_ptr<SocketContext> dSkt) {
 	if (shutdown(dSkt->handle, 1) != 0)
 		WSAError(L"shutdown()"sv);
 
-	auto [code, text] = ReadReplyMessage(Pkt->ctrl_skt, &Canceled[Pkt->ThreadCount]);
+	auto [code, text] = Pkt->ctrl_skt->ReadReply(&Canceled[Pkt->ThreadCount]);
 	if (code / 100 >= FTP_RETRY)
 		SetErrorMsg(std::move(text));
 	if (Pkt->Abort != ABORT_NONE)

--- a/getput.cpp
+++ b/getput.cpp
@@ -192,25 +192,6 @@ void AbortAllTransfer()
 }
 
 
-// 転送するファイル情報をリストに追加する
-int AddTmpTransFileList(TRANSPACKET const& item, std::forward_list<TRANSPACKET>& list) {
-	auto it = before_end(list);
-	list.insert_after(it, item);
-	return FFFTP_SUCCESS;
-}
-
-
-// 転送するファイル情報リストから１つの情報を取り除く
-int RemoveTmpTransFileListItem(std::forward_list<TRANSPACKET>& list, int Num) {
-	for (auto it = list.before_begin(); it != end(list); ++it)
-		if (Num-- == 0) {
-			list.erase_after(it);
-			return FFFTP_SUCCESS;
-		}
-	return FFFTP_FAIL;
-}
-
-
 /*----- 転送するファイル情報を転送ファイルリストに登録する --------------------
 *
 *	Parameter
@@ -245,7 +226,7 @@ void AddNullTransFileList()
 
 
 // 転送ファイル情報を転送ファイルリストに追加する
-void AppendTransFileList(std::forward_list<TRANSPACKET>&& list) {
+void AppendTransFileList(std::vector<TRANSPACKET>&& list) {
 	for (auto& Pkt : list)
 		AddTransFileList(&Pkt);
 }

--- a/socket.cpp
+++ b/socket.cpp
@@ -213,6 +213,31 @@ static CertResult ConfirmSSLCertificate(CtxtHandle& context, wchar_t* serverName
 	return CertResult::Declined;
 }
 
+
+template<class Test>
+static inline std::invoke_result_t<Test> Wait(SocketContext& sc, int* CancelCheckWork, Test test) {
+	for (;;) {
+		if (auto result = test())
+			return result;
+		if (auto result = sc.AsyncFetch(); result != 0 && result != WSA_IO_PENDING)
+			return {};
+		for (auto const expiredAt = std::chrono::steady_clock::now() + std::chrono::seconds{ TimeOut }; SleepEx(0, true) != WAIT_IO_COMPLETION;) {
+			if (expiredAt < std::chrono::steady_clock::now()) {
+				sc.recvStatus = WSAETIMEDOUT;
+				goto error;
+			}
+			if (BackgrndMessageProc() == YES || *CancelCheckWork == YES) {
+				sc.recvStatus = ERROR_OPERATION_ABORTED;
+				goto error;
+			}
+		}
+	}
+error:
+	CancelIo((HANDLE)sc.handle);
+	return {};
+}
+
+
 // SSLセッションを開始
 BOOL SocketContext::AttachSSL(BOOL* pbAborted) {
 	assert(SecIsValidHandle(&credential));
@@ -235,21 +260,19 @@ BOOL SocketContext::AttachSSL(BOOL* pbAborted) {
 
 	sslNeedRenegotiate = true;
 
-	for (;;) {
-		auto result = AsyncFetch();
-		if (result != 0 && result != WSA_IO_PENDING)
-			return FALSE;
-		for (;;) {
-			auto result = SleepEx(0, true);
-			if (result == WAIT_IO_COMPLETION)
-				break;
-			assert(result == 0);
+	auto result = Wait(*this, pbAborted, [this]() -> std::optional<bool> {
+		switch (sslReadStatus) {
+		case SEC_E_OK:
+			return true;
+		case SEC_E_INCOMPLETE_MESSAGE:
+		case SEC_I_CONTINUE_NEEDED:
+			return {};
+		default:
+			return false;
 		}
-		if (sslReadStatus == SEC_E_OK)
-			break;
-		if (sslReadStatus != SEC_E_INCOMPLETE_MESSAGE && sslReadStatus != SEC_I_CONTINUE_NEEDED)
-			return FALSE;
-	}
+	});
+	if (!result || !*result)
+		return FALSE;
 
 	if ((sslReadStatus = QueryContextAttributesW(&sslContext, SECPKG_ATTR_STREAM_SIZES, &sslStreamSizes)) != SEC_E_OK) {
 		Error(L"QueryContextAttributes(SECPKG_ATTR_STREAM_SIZES)"sv, sslReadStatus);
@@ -431,8 +454,10 @@ std::shared_ptr<SocketContext> SocketContext::Accept(_Out_writes_bytes_opt_(*add
 void SocketContext::OnComplete(DWORD error, DWORD transferred, DWORD flags) {
 	_RPTWN(_CRT_WARN, L"SC{%zu}: OnComplete(): error=%u, transferred=%u, flags=%u.\n", handle, error, transferred, flags);
 	readRaw.resize((size_t)readRawSize + transferred);
+	recvStatus = error;
 	if (transferred == 0) {
-		recvStatus = error == 0 ? ERROR_HANDLE_EOF : error;
+		if (error == 0)
+			recvStatus = ERROR_HANDLE_EOF;
 		return;
 	}
 	if (!IsSSLAttached()) {
@@ -511,16 +536,18 @@ void SocketContext::OnComplete(DWORD error, DWORD transferred, DWORD flags) {
 //   WSA_IO_PENDING ... 成功。非同期実行が開始された。
 //   other ............ 失敗。
 int SocketContext::AsyncFetch() {
-	readRawSize = size_as<ULONG>(readRaw);
-	readRaw.resize((size_t)readRawSize + recvlen);
-	readRaw.resize(readRaw.capacity());
-	WSABUF buf{ size_as<ULONG>(readRaw) - readRawSize, data(readRaw) + readRawSize };
-	DWORD flag = 0;
-	auto result = WSARecv(handle, &buf, 1, nullptr, &flag, this, [](DWORD error, DWORD transferred, LPWSAOVERLAPPED overlapped, DWORD flags) { static_cast<SocketContext*>(overlapped)->OnComplete(error, transferred, flags); });
-	recvStatus = result == 0 ? 0 : WSAGetLastError();
-	_RPTWN(_CRT_WARN, L"SC{%zu}: WSARecv(): %d, %d.\n", handle, result, recvStatus);
-	if (recvStatus != 0 && recvStatus != WSA_IO_PENDING)
-		readRaw.resize(readRawSize);
+	if (recvStatus == 0) {
+		readRawSize = size_as<ULONG>(readRaw);
+		readRaw.resize((size_t)readRawSize + recvlen);
+		readRaw.resize(readRaw.capacity());
+		WSABUF buf{ size_as<ULONG>(readRaw) - readRawSize, data(readRaw) + readRawSize };
+		DWORD flag = 0;
+		auto result = WSARecv(handle, &buf, 1, nullptr, &flag, this, [](DWORD error, DWORD transferred, LPWSAOVERLAPPED overlapped, DWORD flags) { static_cast<SocketContext*>(overlapped)->OnComplete(error, transferred, flags); });
+		recvStatus = result == 0 ? 0 : WSAGetLastError();
+		_RPTWN(_CRT_WARN, L"SC{%zu}: WSARecv(): %d, %d.\n", handle, result, recvStatus);
+		if (recvStatus != 0 && recvStatus != WSA_IO_PENDING)
+			readRaw.resize(readRawSize);
+	}
 	return recvStatus;
 }
 
@@ -547,9 +574,9 @@ int SocketContext::GetReadStatus() {
 std::tuple<int, std::wstring> SocketContext::ReadReply(int* CancelCheckWork) {
 	static boost::regex re1{ R"(^[0-9]{3}[- ])" }, re2{ R"(^([0-9]{3})(?:-(?:[^\n]*\n)+?\1)? [^\n]*\n)" };
 	static boost::wregex re3{ LR"((.*?)[ \r]*\n)" }, re4{ LR"([ \r]*\n[0-9]*)" };
-	for (;;) {
+	auto result = Wait(*this, CancelCheckWork, [this]() -> std::optional<std::tuple<int, std::wstring>> {
 		if (4 <= size(readPlain) && !boost::regex_search(begin(readPlain), end(readPlain), re1))
-			goto error;
+			return { { 429, {} } };
 		if (boost::match_results<decltype(readPlain)::iterator> m; boost::regex_search(begin(readPlain), end(readPlain), m, re2)) {
 			auto code = std::stoi(m[1]);
 			auto text = ConvertFrom(sv(m[0]), AskHostNameKanji());
@@ -557,54 +584,34 @@ std::tuple<int, std::wstring> SocketContext::ReadReply(int* CancelCheckWork) {
 			for (boost::wsregex_iterator it{ begin(text), end(text), re3 }, end; it != end; ++it)
 				Notice(IDS_REPLY, sv((*it)[1]));
 			text = boost::regex_replace(text, re4, L" ");
-			return { code, std::move(text) };
+			return { { code, std::move(text) } };
 		}
-		if (auto result = AsyncFetch(); result != 0 && result != WSA_IO_PENDING)
-			goto error;
-		for (;;) {
-			// TODO: timeout
-			auto result = SleepEx(0, true);
-			if (result == WAIT_IO_COMPLETION)
-				break;
-			assert(result == 0);
-			if (BackgrndMessageProc() == YES || *CancelCheckWork == YES)
-				goto error;
-		}
-	}
-error:
-	return { 429, {} };
+		return {};
+	});
+	return result.value_or(std::tuple{ 429, L""s });
 }
 
 
 bool SocketContext::ReadSpan(std::span<char>& span, int* CancelCheckWork) {
-	while (size(readPlain) < size(span)) {
-		if (auto result = AsyncFetch(); result != 0 && result != WSA_IO_PENDING)
-			goto error;
-		for (;;) {
-			// TODO: timeout
-			auto result = SleepEx(0, true);
-			if (result == WAIT_IO_COMPLETION)
-				break;
-			assert(result == 0);
-			if (BackgrndMessageProc() == YES || *CancelCheckWork == YES)
-				goto error;
-		}
-	}
-	std::copy(begin(readPlain), begin(readPlain) + size(span), begin(span));
-	readPlain.erase(begin(readPlain), begin(readPlain) + size(span));
-	return true;
-error:
-	Notice(IDS_MSGJPN244);
-	return false;
+	auto result = Wait(*this, CancelCheckWork, [this, &span] {
+		if (size(readPlain) < size(span))
+			return false;
+		std::copy(begin(readPlain), begin(readPlain) + size(span), begin(span));
+		readPlain.erase(begin(readPlain), begin(readPlain) + size(span));
+		return true;
+	});
+	if (!result)
+		Notice(IDS_MSGJPN244);
+	return result;
 }
 
 
-// 全読み込み。
-//   std::vector ... 読み込み済みのデータ。
-//   int ........... 現在の読み込みステータス。
-std::variant<std::vector<char>, int> SocketContext::ReadAll() {
-	if (!empty(readPlain))
-		return std::exchange(readPlain, {});
+int SocketContext::ReadAll(int* CancelCheckWork, std::function<bool(std::vector<char> const&)> callback) {
+	Wait(*this, CancelCheckWork, [this, &callback] {
+		auto result = callback(readPlain);
+		readPlain.clear();
+		return result;
+	});
 	return GetReadStatus();
 }
 

--- a/socket.cpp
+++ b/socket.cpp
@@ -361,23 +361,14 @@ SocketContext::SocketContext(SOCKET s, std::wstring originalTarget, std::wstring
 }
 
 
-int SocketContext::Close() {
+void SocketContext::Close() {
 	WSAAsyncSelect(handle, hWndSocket, WM_ASYNC_SOCKET, 0);
 	{
 		std::lock_guard lock{ mapMutex };
 		map.erase(handle);
 	}
-	if (int result = closesocket(handle); result != SOCKET_ERROR)
-		return result;
-	for (;;) {
-		if (error != 0)
-			return SOCKET_ERROR;
-		if (GetEvent(FD_CLOSE))
-			return 0;
-		Sleep(1);
-		if (BackgrndMessageProc() == YES)
-			return SOCKET_ERROR;
-	}
+	if (int result = closesocket(handle); result == SOCKET_ERROR)
+		WSAError(L"closesocket()"sv);
 }
 
 

--- a/taskwin.cpp
+++ b/taskwin.cpp
@@ -106,6 +106,7 @@ void DispTaskMsg() {
 void detail::Notice(UINT id, std::wformat_args args) {
 	auto const format = GetString(id);
 	auto message = std::vformat(format, args);
+	_RPTWN(_CRT_WARN, L"N: %s\n", message.c_str());
 	queue.push(std::move(message));
 }
 
@@ -113,6 +114,7 @@ void detail::Debug(std::wstring_view format, std::wformat_args args) {
 	if (DebugConsole != YES)
 		return;
 	auto message = std::vformat(format, args);
+	_RPTWN(_CRT_WARN, L"D: %s\n", message.c_str());
 	message.insert(0, L"## "sv);
 	queue.push(std::move(message));
 }


### PR DESCRIPTION
- 不要なラッパーを削減し、処理をsocket.cppに集約する。
- 非同期処理を導入し、応答速度を改善する。
- `TransPacketBase`を`std::forward_list`から`conncurrent_queue`に移行し、ロックを排除する。
- １ファイル毎に挟まれている200ms待ちを排除する。