### PR TITLE
use /LTCG instead of /LTCG:incremental.

### DIFF
--- a/ffftp.vcxproj
+++ b/ffftp.vcxproj
@@ -184,6 +184,7 @@
       <TargetMachine>MachineX86</TargetMachine>
       <DelayLoadDLLs>COMDLG32.dll;CRYPTUI.dll;RASAPI32.dll;RASDLG.dll;XmlLite.dll;Normaliz.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <MinimumRequiredVersion>6.00</MinimumRequiredVersion>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <MuiResourceCompile>
       <RCConfigFileName>Resource\ffftp.rcconfig</RCConfigFileName>
@@ -214,6 +215,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX64</TargetMachine>
       <DelayLoadDLLs>COMDLG32.dll;CRYPTUI.dll;RASAPI32.dll;RASDLG.dll;XmlLite.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <MuiResourceCompile>
       <RCConfigFileName>Resource\ffftp.rcconfig</RCConfigFileName>


### PR DESCRIPTION
いつの間にかデフォルトが  `/LTCG` から `/LTCG:incremental` に変更されていたらしい。しかし、リリースビルドには  `/LTCG` を使うべきなようだ。少なくとも SizeBench に怒られる。