### PR TITLE
fix #329, split with ascii character.

### DIFF
--- a/common.h
+++ b/common.h
@@ -1018,12 +1018,12 @@ public:
 };
 
 class CodeConverter {
-	const int incode;
 	const int outcode;
 	const bool kana;
 	bool first = true;
 	std::string rest;
 public:
+	const int incode;
 	CodeConverter(int incode, int outcode, bool kana) : incode{ outcode == KANJI_NOCNV || incode == outcode && !kana ? KANJI_NOCNV : incode }, outcode{ outcode }, kana{ kana } {}
 	std::string Convert(std::string_view input);
 };


### PR DESCRIPTION
改行コード `CR LF` や マルチバイト漢字がバッファ境界で分断されないように、ascii文字＋`LF`で分割する。これにより、改行コードや漢字の文字化けを回避する。
