### PR TITLE
転送完了を検出する

### DIFF
--- a/getput.cpp
+++ b/getput.cpp
@@ -721,9 +721,7 @@ static unsigned __stdcall TransferThread(void *Dummy)
 			ClearAll = NO;
 			DelNotify = NO;
 			SetEvent(completed[ThreadCount]);
-			auto result = WaitForMultipleObjects(size_as<DWORD>(completed), completed, true, 0);
-			_RPTWN(_CRT_WARN, L"ID=%d, result=%08X.\n", ThreadCount, result);
-			if (result == WAIT_OBJECT_0) {
+			if (WaitForMultipleObjects(size_as<DWORD>(completed), completed, true, 0) == WAIT_OBJECT_0) {
 				Sound::Transferred.Play();
 				if(AskAutoExit() == NO)
 				{


### PR DESCRIPTION
転送スレッドがローカル変数 `GoExit` で転送完了を検出していたが、複数回の完了が検出されてしまうと共に、スレッド毎にそれぞれ転送完了が検出されていた。
manual reset eventとauto reset eventを使用して、１回のみ転送完了を検出するように修正する。
これにより、 #328 の問題も解消する。