### PR TITLE
アクセッサ関数を削減する

### DIFF
--- a/common.h
+++ b/common.h
@@ -643,18 +643,18 @@ struct Host : HostExeptPassword {
 
 
 struct HOSTDATA : Host {
-	int Level = 0;							/* 設定のレベル */
-											/* 通常はグループのフラグのみが有効 */
-											/* レベル数は設定の登録／呼出時のみで使用 */
-	std::wstring HostName;					/* 設定名 */
-	std::vector<std::wstring> BookMark;		/* ブックマーク */
-	int Anonymous = NO;						/* Anonymousフラグ */
-	int CurNameKanjiCode = KANJI_NOCNV;		/* 自動判別後のファイル名の漢字コード (KANJI_xxx) */
-	int LastDir = NO;						/* 最後にアクセスしたフォルダを保存 */
-	int CryptMode = CRYPT_NONE;				/* 暗号化通信モード (CRYPT_xxx) */
-	int NoDisplayUI = NO;					/* UIを表示しない (YES/NO) */
-	int Feature = 0;						/* 利用可能な機能のフラグ (FEATURE_xxx) */
-	int CurNetType = NTYPE_AUTO;			/* 接続中のネットワークの種類 (NTYPE_xxx) */
+	int Level = 0;									/* 設定のレベル */
+													/* 通常はグループのフラグのみが有効 */
+													/* レベル数は設定の登録／呼出時のみで使用 */
+	std::wstring HostName;							/* 設定名 */
+	std::vector<std::wstring> BookMark;				/* ブックマーク */
+	int Anonymous = NO;								/* Anonymousフラグ */
+	mutable int CurNameKanjiCode = KANJI_NOCNV;		/* 自動判別後のファイル名の漢字コード (KANJI_xxx) */
+	int LastDir = NO;								/* 最後にアクセスしたフォルダを保存 */
+	int CryptMode = CRYPT_NONE;						/* 暗号化通信モード (CRYPT_xxx) */
+	int NoDisplayUI = NO;							/* UIを表示しない (YES/NO) */
+	int Feature = 0;								/* 利用可能な機能のフラグ (FEATURE_xxx) */
+	int CurNetType = NTYPE_AUTO;					/* 接続中のネットワークの種類 (NTYPE_xxx) */
 	HOSTDATA() = default;
 	HOSTDATA(struct HISTORYDATA const& history);
 };
@@ -933,22 +933,18 @@ int SetHostEncryption(int Num, int UseNoEncryption, int UseFTPES, int UseFTPIS, 
 
 /*===== connect.c =====*/
 
+HOSTDATA const& GetCurHost();
 void ConnectProc(int Type, int Num);
 void QuickConnectProc(void);
 void DirectConnectProc(std::wstring&& unc, int Kanji, int Kana, int Fkanji, int TrMode);
 void HistoryConnectProc(int MenuCmd);
-std::wstring_view AskHostAdrs();
-int AskHostPort(void);
-int AskHostNameKanji(void);
 int AskHostNameKana(void);
 int AskListCmdMode(void);
 int AskUseNLST_R(void);
 std::wstring AskHostChmodCmd();
 int AskHostTimeZone(void);
-int AskPasvMode(void);
 std::wstring AskHostLsName();
 int AskHostType(void);
-int AskHostFireWall(void);
 int AskNoFullPathMode(void);
 void SaveCurrentSetToHost(void);
 int ReConnectCmdSkt(void);
@@ -969,28 +965,6 @@ std::optional<sockaddr_storage> SocksReceiveReply(std::shared_ptr<SocketContext>
 std::shared_ptr<SocketContext> connectsock(std::variant<std::wstring_view, std::reference_wrapper<const SocketContext>> originalTarget, std::wstring&& host, int port, UINT prefixId, int *CancelCheckWork);
 std::shared_ptr<SocketContext> GetFTPListenSocket(std::shared_ptr<SocketContext> ctrl_skt, int *CancelCheckWork);
 int AskTryingConnect(void);
-int AskUseNoEncryption(void);
-int AskUseFTPES(void);
-int AskUseFTPIS(void);
-int AskUseSFTP(void);
-// 同時接続対応
-int AskMaxThreadCount(void);
-int AskReuseCmdSkt(void);
-// FEAT対応
-int AskHostFeature(void);
-// MLSD対応
-int AskUseMLSD(void);
-// IPv6対応
-int AskCurNetType(void);
-// 自動切断対策
-int AskNoopInterval(void);
-// 再転送対応
-int AskTransferErrorMode(void);
-int AskTransferErrorNotify(void);
-// セッションあたりの転送量制限対策
-int AskErrorReconnect(void);
-// ホスト側の設定ミス対策
-int AskNoPasvAdrs(void);
 
 // キャッシュのファイル名を作成する
 static inline fs::path MakeCacheFileName(int num) {

--- a/filelist.cpp
+++ b/filelist.cpp
@@ -55,7 +55,6 @@ extern std::wstring FilterStr;
 extern int SuppressRefresh;
 // ローカル側自動更新
 extern HANDLE ChangeNotification;
-extern HOSTDATA CurHost;
 
 /*===== ローカルなワーク =====*/
 
@@ -1456,7 +1455,7 @@ void AddRemoteTreeToFileList(int Num, std::wstring const& Path, int IncDir, std:
 						if (str.starts_with("./"sv) || str.starts_with(".\\"sv))
 							str = str.substr(2);
 						if (1 < size(str))
-							Dir = ReplaceAll(SetSlashTail(std::wstring{ Path }) + ConvertFrom(str, CurHost.CurNameKanjiCode), L'\\', L'/');
+							Dir = ReplaceAll(SetSlashTail(std::wstring{ Path }) + ConvertFrom(str, GetCurHost().CurNameKanjiCode), L'\\', L'/');
 					}
 					if (IncDir == RDIR_NLST)
 						AddFileList({ Dir, NODE_DIR }, Base);
@@ -1876,17 +1875,18 @@ static std::optional<std::vector<std::variant<FILELIST, std::string>>> GetListLi
 		else
 			lines.emplace_back(std::move(line));
 	}
-	if (CurHost.NameKanjiCode == KANJI_AUTO) {
+	auto const& curHost = GetCurHost();
+	if (curHost.NameKanjiCode == KANJI_AUTO) {
 		CodeDetector cd;
 		for (auto const& line : lines)
 			if (auto p = std::get_if<FILELIST>(&line); p && p->Node != NODE_NONE && !empty(p->Original))
 				cd.Test(p->Original);
-		CurHost.CurNameKanjiCode = cd.result();
+		curHost.CurNameKanjiCode = cd.result();
 	} else
-		CurHost.CurNameKanjiCode = CurHost.NameKanjiCode;
+		curHost.CurNameKanjiCode = curHost.NameKanjiCode;
 	for (auto& line : lines) {
 		if (auto p = std::get_if<FILELIST>(&line); p && p->Node != NODE_NONE && !empty(p->Original)) {
-			auto file = ConvertFrom(p->Original, CurHost.CurNameKanjiCode);
+			auto file = ConvertFrom(p->Original, curHost.CurNameKanjiCode);
 			if (auto last = file.back(); last == '/' || last == '\\')
 				file.resize(file.size() - 1);
 			if (empty(file) || file == L"."sv || file == L".."sv)

--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -2146,9 +2146,8 @@ void CopyURLtoClipBoard() {
 	MakeSelectedFileList(WIN_REMOTE, NO, NO, FileListBase, &CancelFlg);
 	if (empty(FileListBase))
 		return;
-	auto baseAddress = L"ftp://"s + AskHostAdrs();
-	if (auto port = AskHostPort(); port != IPPORT_FTP)
-		baseAddress.append(L":").append(std::to_wstring(port));
+	auto const curHost = GetCurHost();
+	auto baseAddress = std::format(curHost.Port != IPPORT_FTP ? L"ftp://{0}:{1}"sv : L"ftp://{0}"sv, curHost.HostAdrs, curHost.Port);
 	{
 		auto dir = SetSlashTail(std::wstring{ AskRemoteCurDir() });
 		if (AskHostType() == HTYPE_VMS) {
@@ -2255,8 +2254,7 @@ void NoopProc(int Force)
 {
 	if(Force == YES || (AskConnecting() == YES && !AskUserOpeDisabled()))
 	{
-		if(AskReuseCmdSkt() == NO || (AskShareProh() == YES && AskTransferNow() == NO))
-		{
+		if (GetCurHost().ReuseCmdSkt == NO || AskShareProh() == YES && AskTransferNow() == NO) {
 			if(Force == NO)
 				CancelFlg = NO;
 			DisableUserOpe();
@@ -2271,11 +2269,9 @@ void AbortRecoveryProc(void)
 {
 	if(AskConnecting() == YES && !AskUserOpeDisabled())
 	{
-		if(AskReuseCmdSkt() == NO || AskShareProh() == YES || AskTransferNow() == NO)
-		{
+		if (auto const& curHost = GetCurHost(); curHost.ReuseCmdSkt == NO || AskShareProh() == YES || AskTransferNow() == NO) {
 			CancelFlg = NO;
-			if(AskErrorReconnect() == YES)
-			{
+			if (curHost.TransferErrorReconnect == YES) {
 				DisableUserOpe();
 				ReConnectCmdSkt();
 				GetRemoteDirForWnd(CACHE_REFRESH, &CancelFlg);

--- a/main.cpp
+++ b/main.cpp
@@ -671,8 +671,7 @@ static LRESULT CALLBACK FtpWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARA
 				}
 				if(CancelFlg == YES)
 					AbortRecoveryProc();
-				if(NoopEnable == YES && AskNoopInterval() > 0 && time(NULL) - LastDataConnectionTime >= AskNoopInterval())
-				{
+				if (auto const& curHost = GetCurHost(); NoopEnable == YES && curHost.NoopInterval > 0 && time(NULL) - LastDataConnectionTime >= curHost.NoopInterval) {
 					NoopProc(NO);
 					LastDataConnectionTime = time(NULL);
 				}

--- a/socket.cpp
+++ b/socket.cpp
@@ -568,7 +568,7 @@ std::tuple<int, std::wstring> SocketContext::ReadReply(int* CancelCheckWork) {
 			return { { 429, {} } };
 		if (boost::match_results<decltype(readPlain)::iterator> m; boost::regex_search(begin(readPlain), end(readPlain), m, re2)) {
 			auto code = std::stoi(m[1]);
-			auto text = ConvertFrom(sv(m[0]), AskHostNameKanji());
+			auto text = ConvertFrom(sv(m[0]), GetCurHost().CurNameKanjiCode);
 			readPlain.erase(m[0].first, m[0].second);
 			for (boost::wsregex_iterator it{ begin(text), end(text), re3 }, end; it != end; ++it)
 				Notice(IDS_REPLY, sv((*it)[1]));


### PR DESCRIPTION
`CurHost`の各メンバーを参照するアクセッサ関数が多数定義されているが、`CurHost`自身を`const&`で公開する。