### PR TITLE
HostSort構造体の導入

### DIFF
--- a/connect.cpp
+++ b/connect.cpp
@@ -93,11 +93,6 @@ static bool SplitUNCpath(std::wstring&& unc, std::wstring& Host, std::wstring& P
 
 void ConnectProc(int Type, int Num)
 {
-	int LFSort;
-	int LDSort;
-	int RFSort;
-	int RDSort;
-
 	SaveBookMark();
 	SaveCurrentSetToHost();
 
@@ -122,10 +117,8 @@ void ConnectProc(int Type, int Num)
 			SetHostKanjiCodeImm(CurHost.KanjiCode);
 			SetSyncMoveMode(CurHost.SyncMove);
 
-			if((AskSaveSortToHost() == YES) && (CurHost.Sort != SORT_NOTSAVED))
-			{
-				DecomposeSortType(CurHost.Sort, &LFSort, &LDSort, &RFSort, &RDSort);
-				SetSortTypeImm(LFSort, LDSort, RFSort, RDSort);
+			if (AskSaveSortToHost() == YES && CurHost.Sort != HostSort::NotSaved()) {
+				SetSortTypeImm(CurHost.Sort);
 				ReSortDispList(WIN_LOCAL, &CancelFlg);
 			}
 
@@ -405,11 +398,6 @@ void DirectConnectProc(std::wstring&& unc, int Kanji, int Kana, int Fkanji, int 
 
 void HistoryConnectProc(int MenuCmd)
 {
-	int LFSort;
-	int LDSort;
-	int RFSort;
-	int RDSort;
-
 	if (auto history = GetHistoryByCmd(MenuCmd)) {
 		SaveBookMark();
 		SaveCurrentSetToHost();
@@ -431,8 +419,7 @@ void HistoryConnectProc(int MenuCmd)
 			SetHostKanjiCodeImm(CurHost.KanjiCode);
 			SetSyncMoveMode(CurHost.SyncMove);
 
-			DecomposeSortType(CurHost.Sort, &LFSort, &LDSort, &RFSort, &RDSort);
-			SetSortTypeImm(LFSort, LDSort, RFSort, RDSort);
+			SetSortTypeImm(CurHost.Sort);
 			ReSortDispList(WIN_LOCAL, &CancelFlg);
 
 			SetTransferTypeImm(history->Type);
@@ -726,7 +713,7 @@ void SaveCurrentSetToHost(void)
 			CopyHostFromListInConnect(Host, &TmpHost);
 			if(TmpHost.LastDir == YES)
 				SetHostDir(AskCurrentHost(), AskLocalCurDir().native(), AskRemoteCurDir());
-			SetHostSort(AskCurrentHost(), AskSortType(ITEM_LFILE), AskSortType(ITEM_LDIR), AskSortType(ITEM_RFILE), AskSortType(ITEM_RDIR));
+			SetHostSort(AskCurrentHost(), AskSortType());
 		}
 	}
 	return;
@@ -747,7 +734,7 @@ static void SaveCurrentSetToHistory(void)
 	CurHost.LocalInitDir = AskLocalCurDir();
 	CurHost.RemoteInitDir = AskRemoteCurDir();
 
-	CurHost.Sort = AskSortType(ITEM_LFILE) * 0x1000000 | AskSortType(ITEM_LDIR) * 0x10000 | AskSortType(ITEM_RFILE) * 0x100 | AskSortType(ITEM_RDIR);
+	CurHost.Sort = AskSortType();
 
 	CurHost.KanjiCode = AskHostKanjiCode();
 	CurHost.KanaCnv = AskHostKanaCnv();

--- a/filelist.cpp
+++ b/filelist.cpp
@@ -724,7 +724,7 @@ static void DispFileList2View(HWND hWnd, std::vector<FILELIST>& files) {
 	std::sort(begin(files), end(files), [hWnd](FILELIST& l, FILELIST& r) {
 		if (l.Node != r.Node)
 			return l.Node < r.Node;
-		auto Sort = AskSortType(hWnd == GetRemoteHwnd() ? l.Node == NODE_DIR ? ITEM_RDIR : ITEM_RFILE : l.Node == NODE_DIR ? ITEM_LDIR : ITEM_LFILE);
+		auto Sort = hWnd == GetRemoteHwnd() ? l.Node == NODE_DIR ? AskSortType().RemoteDirectory : AskSortType().RemoteFile : l.Node == NODE_DIR ? AskSortType().LocalDirectory : AskSortType().LocalFile;
 		auto test = [ascent = (Sort & SORT_GET_ORD) == SORT_ASCENT](auto r) { return ascent ? r < 0 : r > 0; };
 		LONGLONG Cmp = 0;
 		fs::path lf{ l.Name }, rf{ r.Name };

--- a/hostman.cpp
+++ b/hostman.cpp
@@ -646,39 +646,12 @@ int SearchHostName(std::wstring_view name) {
 
 
 // 設定値リストのソート方法を更新
-//   int LFSort : ローカルのファイルのソート方法
-//   int LDSort : ローカルのフォルダのソート方法
-//   int RFSort : リモートのファイルのソート方法
-//   int RDSort : リモートのフォルダのソート方法
-int SetHostSort(int Num, int LFSort, int LDSort, int RFSort, int RDSort) {
+int SetHostSort(int Num, HostSort const& sort) {
 	if (Num < 0 || Hosts <= Num)
 		return FFFTP_FAIL;
 	auto Pos = GetNode(Num);
-	Pos->Sort = LFSort * 0x1000000 | LDSort * 0x10000 | RFSort * 0x100 | RDSort;
+	Pos->Sort = sort;
 	return FFFTP_SUCCESS;
-}
-
-
-/*----- 登録されているソート方法を分解する ------------------------------------
-*
-*	Parameter
-*		uint32_t Sort : ソート方法 
-*		int *LFSort : ローカルのファイルのソート方法を格納するワーク
-*		int *LDSort : ローカルのフォルダのソート方法を格納するワーク
-*		int *RFSort : リモートのファイルのソート方法を格納するワーク
-*		int *RDSort : リモートのフォルダのソート方法を格納するワーク
-*
-*	Return Value
-*		なし
-*----------------------------------------------------------------------------*/
-
-void DecomposeSortType(uint32_t Sort, int *LFSort, int *LDSort, int *RFSort, int *RDSort)
-{
-	*LFSort = (int)((Sort / 0x1000000) & 0xFF);
-	*LDSort = (int)((Sort / 0x10000) & 0xFF);
-	*RFSort = (int)((Sort / 0x100) & 0xFF);
-	*RDSort = (int)(Sort & 0xFF);
-	return;
 }
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -406,7 +406,7 @@ static int InitApp(int cmdShow)
 				if (std::error_code ec; !empty(DefaultLocalPath))
 					fs::current_path(DefaultLocalPath, ec);
 
-				SetSortTypeImm(LocalFileSort, LocalDirSort, RemoteFileSort, RemoteDirSort);
+				SetSortTypeImm(Sort);
 				SetTransferTypeImm(TransMode);
 				DispTransferType();
 				SetHostKanaCnvImm(YES);
@@ -983,10 +983,7 @@ static LRESULT CALLBACK FtpWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARA
 					{
 						// 同時接続対応
 						CancelFlg = NO;
-						LocalFileSort = AskSortType(ITEM_LFILE);
-						LocalDirSort = AskSortType(ITEM_LDIR);
-						RemoteFileSort = AskSortType(ITEM_RFILE);
-						RemoteDirSort = AskSortType(ITEM_RDIR);
+						Sort = AskSortType();
 						ReSortDispList(WIN_LOCAL, &CancelFlg);
 						ReSortDispList(WIN_REMOTE, &CancelFlg);
 					}

--- a/option.cpp
+++ b/option.cpp
@@ -702,33 +702,34 @@ int SortSetting() {
 		using RsortOrdButton = RadioButton<SORT_RFILE_NAME, SORT_RFILE_EXT, SORT_RFILE_SIZE, SORT_RFILE_DATE>;
 		using RDirsortOrdButton = RadioButton<SORT_RDIR_NAME, SORT_RDIR_DATE>;
 		INT_PTR OnInit(HWND hDlg) {
-			LsortOrdButton::Set(hDlg, AskSortType(ITEM_LFILE) & SORT_MASK_ORD);
-			SendDlgItemMessageW(hDlg, SORT_LFILE_REV, BM_SETCHECK, (AskSortType(ITEM_LFILE) & SORT_GET_ORD) != SORT_ASCENT, 0);
-			LDirsortOrdButton::Set(hDlg, AskSortType(ITEM_LDIR) & SORT_MASK_ORD);
-			SendDlgItemMessageW(hDlg, SORT_LDIR_REV, BM_SETCHECK, (AskSortType(ITEM_LDIR) & SORT_GET_ORD) != SORT_ASCENT, 0);
-			RsortOrdButton::Set(hDlg, AskSortType(ITEM_RFILE) & SORT_MASK_ORD);
-			SendDlgItemMessageW(hDlg, SORT_RFILE_REV, BM_SETCHECK, (AskSortType(ITEM_RFILE) & SORT_GET_ORD) != SORT_ASCENT, 0);
-			RDirsortOrdButton::Set(hDlg, AskSortType(ITEM_RDIR) & SORT_MASK_ORD);
-			SendDlgItemMessageW(hDlg, SORT_RDIR_REV, BM_SETCHECK, (AskSortType(ITEM_RDIR) & SORT_GET_ORD) != SORT_ASCENT, 0);
+			LsortOrdButton::Set(hDlg, AskSortType().LocalFile & SORT_MASK_ORD);
+			SendDlgItemMessageW(hDlg, SORT_LFILE_REV, BM_SETCHECK, (AskSortType().LocalFile & SORT_GET_ORD) != SORT_ASCENT, 0);
+			LDirsortOrdButton::Set(hDlg, AskSortType().LocalDirectory & SORT_MASK_ORD);
+			SendDlgItemMessageW(hDlg, SORT_LDIR_REV, BM_SETCHECK, (AskSortType().LocalDirectory & SORT_GET_ORD) != SORT_ASCENT, 0);
+			RsortOrdButton::Set(hDlg, AskSortType().RemoteFile & SORT_MASK_ORD);
+			SendDlgItemMessageW(hDlg, SORT_RFILE_REV, BM_SETCHECK, (AskSortType().RemoteFile & SORT_GET_ORD) != SORT_ASCENT, 0);
+			RDirsortOrdButton::Set(hDlg, AskSortType().RemoteDirectory & SORT_MASK_ORD);
+			SendDlgItemMessageW(hDlg, SORT_RDIR_REV, BM_SETCHECK, (AskSortType().RemoteDirectory & SORT_GET_ORD) != SORT_ASCENT, 0);
 			SendDlgItemMessageW(hDlg, SORT_SAVEHOST, BM_SETCHECK, AskSaveSortToHost(), 0);
 			return TRUE;
 		}
 		void OnCommand(HWND hDlg, WORD id) {
 			switch (id) {
 			case IDOK: {
-				auto LFsort = LsortOrdButton::Get(hDlg);
+				HostSort sort;
+				sort.LocalFile = LsortOrdButton::Get(hDlg);
 				if (SendDlgItemMessageW(hDlg, SORT_LFILE_REV, BM_GETCHECK, 0, 0) == 1)
-					LFsort |= SORT_DESCENT;
-				auto LDsort = LDirsortOrdButton::Get(hDlg);
+					sort.LocalFile |= SORT_DESCENT;
+				sort.LocalDirectory = LDirsortOrdButton::Get(hDlg);
 				if (SendDlgItemMessageW(hDlg, SORT_LDIR_REV, BM_GETCHECK, 0, 0) == 1)
-					LDsort |= SORT_DESCENT;
-				auto RFsort = RsortOrdButton::Get(hDlg);
+					sort.LocalDirectory |= SORT_DESCENT;
+				sort.RemoteFile = RsortOrdButton::Get(hDlg);
 				if (SendDlgItemMessageW(hDlg, SORT_RFILE_REV, BM_GETCHECK, 0, 0) == 1)
-					RFsort |= SORT_DESCENT;
-				auto RDsort = RDirsortOrdButton::Get(hDlg);
+					sort.RemoteFile |= SORT_DESCENT;
+				sort.RemoteDirectory = RDirsortOrdButton::Get(hDlg);
 				if (SendDlgItemMessageW(hDlg, SORT_RDIR_REV, BM_GETCHECK, 0, 0) == 1)
-					RDsort |= SORT_DESCENT;
-				SetSortTypeImm(LFsort, LDsort, RFsort, RDsort);
+					sort.RemoteDirectory |= SORT_DESCENT;
+				SetSortTypeImm(sort);
 				SetSaveSortToHost((int)SendDlgItemMessageW(hDlg, SORT_SAVEHOST, BM_GETCHECK, 0, 0));
 				EndDialog(hDlg, YES);
 				break;

--- a/registry.cpp
+++ b/registry.cpp
@@ -327,7 +327,7 @@ void Config::WriteHost(Host const& host, Host const& defaultHost, bool writePass
 	WriteBinary("Sort"sv, host.Sort);
 }
 
-static constexpr std::tuple<std::string_view, std::variant<int*, std::wstring*, std::vector<std::wstring>*>> settings[] = {
+static constexpr std::tuple<std::string_view, std::variant<int*, uint8_t*, std::wstring*, std::vector<std::wstring>*>> settings[] = {
 	{ "WinPosX"sv, &WinPosX },
 	{ "WinPosY"sv, &WinPosY },
 	{ "WinWidth"sv, &WinWidth },
@@ -349,10 +349,10 @@ static constexpr std::tuple<std::string_view, std::variant<int*, std::wstring*, 
 	{ "Scolon"sv, &VaxSemicolon },
 	{ "RecvEx"sv, &ExistMode },
 	{ "SendEx"sv, &UpExistMode },
-	{ "LFsort"sv, &LocalFileSort },
-	{ "LDsort"sv, &LocalDirSort },
-	{ "RFsort"sv, &RemoteFileSort },
-	{ "RDsort"sv, &RemoteDirSort },
+	{ "LFsort"sv, &Sort.LocalFile },
+	{ "LDsort"sv, &Sort.LocalDirectory },
+	{ "RFsort"sv, &Sort.RemoteFile },
+	{ "RDsort"sv, &Sort.RemoteDirectory },
 	{ "SortSave"sv, &SortSave },
 	{ "ListType"sv, &ListType },
 	{ "DotFile"sv, &DotFile },

--- a/toolmenu.cpp
+++ b/toolmenu.cpp
@@ -41,10 +41,7 @@ static int TmpHostKanjiCode;
 static int TmpHostKanaCnv;
 // TODO: ローカルの漢字コードをShift_JIS以外にも対応
 static int TmpLocalKanjiCode;
-static int TmpLocalFileSort;
-static int TmpLocalDirSort;
-static int TmpRemoteFileSort;
-static int TmpRemoteDirSort;
+static HostSort TmpSort;
 static int SyncMove = NO;
 static int HideUI = 0;
 static fs::path LocalCurDir;
@@ -637,43 +634,26 @@ int AskHostKanaCnv() {
 *===================================================*/
 
 // ソート方法をセットする
-//   LFsort : ローカル側のファイルのソート方法 (SORT_xxx)
-//   LDsort : ローカル側のディレクトリのソート方法 (SORT_xxx)
-//   RFsort : ホスト側のファイルのソート方法 (SORT_xxx)
-//   RDsort : ホスト側のディレクトリのソート方法 (SORT_xxx)
-void SetSortTypeImm(int LFsort, int LDsort, int RFsort, int RDsort) {
-	TmpLocalFileSort = LFsort;
-	TmpLocalDirSort = LDsort;
-	TmpRemoteFileSort = RFsort;
-	TmpRemoteDirSort = RDsort;
+void SetSortTypeImm(HostSort const& sort) {
+	TmpSort = sort;
 }
 
 
 // リストビューのタブクリックによるソート方法のセット
 void SetSortTypeByColumn(int Win, int Tab) {
 	if (Win == WIN_LOCAL) {
-		TmpLocalFileSort = (TmpLocalFileSort & SORT_MASK_ORD) == Tab ? TmpLocalFileSort ^ SORT_GET_ORD : Tab;
-		TmpLocalDirSort = Tab == SORT_NAME || Tab == SORT_DATE ? TmpLocalFileSort : SORT_NAME;
+		TmpSort.LocalFile = (TmpSort.LocalFile & SORT_MASK_ORD) == Tab ? TmpSort.LocalFile ^ SORT_GET_ORD : Tab;
+		TmpSort.LocalDirectory = Tab == SORT_NAME || Tab == SORT_DATE ? TmpSort.LocalFile : SORT_NAME;
 	} else if (Tab != 4) {
-		TmpRemoteFileSort = (TmpRemoteFileSort & SORT_MASK_ORD) == Tab ? TmpRemoteFileSort ^ SORT_GET_ORD : Tab;
-		TmpRemoteDirSort = Tab == SORT_NAME || Tab == SORT_DATE ? TmpRemoteFileSort : SORT_NAME;
+		TmpSort.RemoteFile = (TmpSort.RemoteFile & SORT_MASK_ORD) == Tab ? TmpSort.RemoteFile ^ SORT_GET_ORD : Tab;
+		TmpSort.RemoteDirectory = Tab == SORT_NAME || Tab == SORT_DATE ? TmpSort.RemoteFile : SORT_NAME;
 	}
 }
 
 
 // ソート方法を返す
-int AskSortType(int Name) {
-	switch (Name) {
-	case ITEM_LFILE:
-		return TmpLocalFileSort;
-	case ITEM_LDIR:
-		return TmpLocalDirSort;
-	case ITEM_RFILE:
-		return TmpRemoteFileSort;
-	case ITEM_RDIR:
-		return TmpRemoteDirSort;
-	}
-	return TmpLocalFileSort;
+HostSort const& AskSortType() {
+	return TmpSort;
 }
 
 


### PR DESCRIPTION
今までソート状態を表すデータが`uint32_t`の場合と`int`ｘ４つの場合があり、相互変換の関数が用意されていたり、されておらずにインラインで変換していたり、とバラバラな実装になっていた。
ここで`HostSort`構造体を導入し、形式を統一する。これにより相互変換は不要になり、代入や比較もカプセル化される。

併せて、設定項目に`int`以外の整数も利用する（今までは`int`のみに制限されていた）。