### PR TITLE
TimeOut=0をタイムアウトなしと見なす

### DIFF
--- a/Resource/ffftp.en-US.rc
+++ b/Resource/ffftp.en-US.rc
@@ -2541,7 +2541,6 @@ STRINGTABLE
 BEGIN
     IDS_MSGJPN241           "Failed transmit cause of timeout"
     IDS_MSGJPN242           "Failed receive cause of timeout"
-    IDS_MSGJPN243           "Failed receive cause of timeout"
     IDS_MSGJPN244           "Receive length error"
     IDS_MSGJPN245           "Local"
     IDS_MSGJPN246           "Host"

--- a/Resource/ffftp.ja-JP.rc
+++ b/Resource/ffftp.ja-JP.rc
@@ -2505,7 +2505,6 @@ STRINGTABLE
 BEGIN
     IDS_MSGJPN241           "送信はタイムアウトで失敗しました."
     IDS_MSGJPN242           "受信はタイムアウトで失敗しました."
-    IDS_MSGJPN243           "受信はタイムアウトで失敗しました."
     IDS_MSGJPN244           "固定長の受信が失敗しました"
     IDS_MSGJPN245           "ローカル"
     IDS_MSGJPN246           "ホスト"

--- a/Resource/resource.en-US.h
+++ b/Resource/resource.en-US.h
@@ -634,7 +634,6 @@
 #define IDS_MSGJPN239                   10239
 #define IDS_MSGJPN241                   10241
 #define IDS_MSGJPN242                   10242
-#define IDS_MSGJPN243                   10243
 #define IDS_MSGJPN244                   10244
 #define IDS_MSGJPN245                   10245
 #define IDS_MSGJPN246                   10246

--- a/Resource/resource.ja-JP.h
+++ b/Resource/resource.ja-JP.h
@@ -634,7 +634,6 @@
 #define IDS_MSGJPN239                   10239
 #define IDS_MSGJPN241                   10241
 #define IDS_MSGJPN242                   10242
-#define IDS_MSGJPN243                   10243
 #define IDS_MSGJPN244                   10244
 #define IDS_MSGJPN245                   10245
 #define IDS_MSGJPN246                   10246

--- a/common.h
+++ b/common.h
@@ -461,7 +461,7 @@ inline int DotFile = YES;
 inline int DclickOpen = YES;
 inline int ConnectAndSet = YES;
 inline int FnameCnv = FNAME_NOCNV;
-inline int TimeOut = 90;
+inline int TimeOut = 90;				// 0～300秒; 0=タイムアウトなし
 inline int RmEOF = NO;
 inline int RegType = REGTYPE_REG;
 inline std::wstring FwallHost;

--- a/socket.cpp
+++ b/socket.cpp
@@ -217,7 +217,8 @@ static inline std::invoke_result_t<Test> Wait(SocketContext& sc, int* CancelChec
 		if (auto result = sc.AsyncFetch(); result != 0 && result != WSA_IO_PENDING)
 			return {};
 		for (auto const expiredAt = std::chrono::steady_clock::now() + std::chrono::seconds{ TimeOut }; SleepEx(0, true) != WAIT_IO_COMPLETION;) {
-			if (expiredAt < std::chrono::steady_clock::now()) {
+			if (TimeOut != 0 && expiredAt < std::chrono::steady_clock::now()) {
+				Notice(IDS_MSGJPN242);
 				sc.recvStatus = WSAETIMEDOUT;
 				goto error;
 			}


### PR DESCRIPTION
#352 で判明。TimeOut値をそのまま扱ったため、`0`は即座にタイムアウトが発生していた。しかし、本来はタイムアウトなしとして扱うのが正しい。