### PR TITLE
ソケットの終了処理の改善

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "boost-regex"]
 	path = boost-regex
 	url = https://github.com/boostorg/regex.git
+[submodule "gsl"]
+	path = gsl
+	url = https://github.com/microsoft/GSL.git

--- a/Resource/ffftp.en-US.rc
+++ b/Resource/ffftp.en-US.rc
@@ -2311,7 +2311,6 @@ BEGIN
     IDS_MSGJPN002           "Connection cancelled."
     IDS_MSGJPN003           "\r\nReconnect.\r\n"
     IDS_MSGJPN004           "Disconnect."
-    IDS_MSGJPN005           "Connection was killed."
     IDS_MSGJPN006           "Cannnot login to Firewall."
     IDS_MSGJPN007           "Cannnot connect to host {}."
     IDS_MSGJPN008           "Cannnot login."

--- a/Resource/ffftp.ja-JP.rc
+++ b/Resource/ffftp.ja-JP.rc
@@ -2275,7 +2275,6 @@ BEGIN
     IDS_MSGJPN002           "接続を中止しました."
     IDS_MSGJPN003           "\r\n再接続します.\r\n"
     IDS_MSGJPN004           "切断しました"
-    IDS_MSGJPN005           "接続が切断されました."
     IDS_MSGJPN006           "FireWallにログインできません."
     IDS_MSGJPN007           "ホスト {} に接続できません."
     IDS_MSGJPN008           "ログインできません."

--- a/Resource/resource.en-US.h
+++ b/Resource/resource.en-US.h
@@ -464,7 +464,6 @@
 #define IDS_MSGJPN002                   10002
 #define IDS_MSGJPN003                   10003
 #define IDS_MSGJPN004                   10004
-#define IDS_MSGJPN005                   10005
 #define IDS_MSGJPN006                   10006
 #define IDS_MSGJPN007                   10007
 #define IDS_MSGJPN008                   10008

--- a/Resource/resource.ja-JP.h
+++ b/Resource/resource.ja-JP.h
@@ -464,7 +464,6 @@
 #define IDS_MSGJPN002                   10002
 #define IDS_MSGJPN003                   10003
 #define IDS_MSGJPN004                   10004
-#define IDS_MSGJPN005                   10005
 #define IDS_MSGJPN006                   10006
 #define IDS_MSGJPN007                   10007
 #define IDS_MSGJPN008                   10008

--- a/common.h
+++ b/common.h
@@ -28,7 +28,6 @@
 
 #pragma once
 #define _CRT_SECURE_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
 #define NOMINMAX
 #define SECURITY_WIN32
 #define WIN32_LEAN_AND_MEAN
@@ -138,8 +137,6 @@ constexpr FileType AllFileTyes[]{ FileType::All, FileType::Executable, FileType:
 
 #define WM_CHANGE_COND	(WM_USER+1)	/* ファイル一覧を変更するコマンド */
 #define WM_SET_PACKET	(WM_USER+2)	/* 現在使用している転送パケットのアドレスを通知 */
-
-#define WM_ASYNC_SOCKET	(WM_USER+5)
 
 #define WM_REFRESH_LOCAL_FLG	(WM_USER+7)
 #define WM_REFRESH_REMOTE_FLG	(WM_USER+8)
@@ -538,8 +535,6 @@ struct SocketContext : public WSAOVERLAPPED {
 	SOCKET const handle;
 	std::wstring const originalTarget;
 	std::wstring const punyTarget;
-	int event = 0;
-	int error = 0;
 	int mapPort = 0;
 	std::variant<sockaddr_storage, std::tuple<std::wstring, int>> target;
 	CtxtHandle sslContext = CreateInvalidateHandle<CtxtHandle>();
@@ -566,7 +561,6 @@ struct SocketContext : public WSAOVERLAPPED {
 		return SecIsValidHandle(&sslContext);
 	}
 	std::vector<char> Encrypt(std::string_view plain);
-	bool GetEvent(int mask);
 	int Connect(const sockaddr* name, int namelen, int* CancelCheckWork);
 	int Listen(int backlog);
 	void OnComplete(DWORD error, DWORD transferred, DWORD flags);
@@ -1191,8 +1185,6 @@ BOOL LoadSSL();
 void FreeSSL();
 void ShowCertificate();
 bool IsSecureConnection();
-int MakeSocketWin();
-void DeleteSocketWin(void);
 // UPnP対応
 int LoadUPnP();
 void FreeUPnP();

--- a/common.h
+++ b/common.h
@@ -58,6 +58,7 @@
 #include <vector>
 #include <concurrent_queue.h>
 #include <boost/regex.hpp>
+#include <gsl/gsl>
 #include <cassert>
 #include <cwctype>
 #include <crtdbg.h>

--- a/common.h
+++ b/common.h
@@ -549,13 +549,9 @@ struct SocketContext : public WSAOVERLAPPED {
 
 	inline SocketContext(SOCKET s, std::wstring originalTarget, std::wstring punyTarget);
 	SocketContext(SocketContext const&) = delete;
-	~SocketContext() {
-		if (SecIsValidHandle(&sslContext))
-			DeleteSecurityContext(&sslContext);
-	}
+	inline ~SocketContext();
 	static std::shared_ptr<SocketContext> Create(int af, std::variant<std::wstring_view, std::reference_wrapper<const SocketContext>> originalTarget);
 	std::shared_ptr<SocketContext> Accept(_Out_writes_bytes_opt_(*addrlen) struct sockaddr* addr, _Inout_opt_ int* addrlen);
-	void Close();
 	BOOL AttachSSL(BOOL* pbAborted);
 	constexpr bool IsSSLAttached() {
 		return SecIsValidHandle(&sslContext);
@@ -1020,7 +1016,6 @@ int DoSIZE(std::shared_ptr<SocketContext> cSkt, std::wstring const& Path, LONGLO
 int DoMDTM(std::shared_ptr<SocketContext> cSkt, std::wstring const& Path, FILETIME *Time, int *CancelCheckWork);
 int DoMFMT(std::shared_ptr<SocketContext> cSkt, std::wstring const&, FILETIME *Time, int *CancelCheckWork);
 int DoQUOTE(std::shared_ptr<SocketContext> cSkt, std::wstring_view CmdStr, int* CancelCheckWork);
-void DoClose(std::shared_ptr<SocketContext> Sock);
 int DoQUIT(std::shared_ptr<SocketContext> ctrl_skt, int *CancelCheckWork);
 int DoDirList(std::wstring_view AddOpt, int Num, int* CancelCheckWork);
 #if defined(HAVE_TANDEM)

--- a/ffftp.vcxproj
+++ b/ffftp.vcxproj
@@ -70,7 +70,7 @@
     <CodeAnalysisRuleSet>ffftp.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-    <IncludePath>boost-regex/include;$(IncludePath)</IncludePath>
+    <IncludePath>boost-regex/include;gsl/include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(Configuration)\$(PlatformTarget)\</OutDir>
@@ -79,7 +79,7 @@
     <CodeAnalysisRuleSet>ffftp.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-    <IncludePath>boost-regex/include;$(IncludePath)</IncludePath>
+    <IncludePath>boost-regex/include;gsl/include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(Configuration)\$(PlatformTarget)\</OutDir>
@@ -88,7 +88,7 @@
     <CodeAnalysisRuleSet>ffftp.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-    <IncludePath>boost-regex/include;$(IncludePath)</IncludePath>
+    <IncludePath>boost-regex/include;gsl/include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(Configuration)\$(PlatformTarget)\</OutDir>
@@ -97,7 +97,7 @@
     <CodeAnalysisRuleSet>ffftp.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-    <IncludePath>boost-regex/include;$(IncludePath)</IncludePath>
+    <IncludePath>boost-regex/include;gsl/include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/main.cpp
+++ b/main.cpp
@@ -251,6 +251,10 @@ int WINAPI wWinMain(__in HINSTANCE hInstance, __in_opt HINSTANCE hPrevInstance, 
 		}
 		exitCode = (int)msg.wParam;
 	}
+	// TODO: グローバルに保持されているSocketContextの解放。遅延させると各種エラーが発生するため明示的にここで行う。
+	MainTransPkt.ctrl_skt.reset();
+	DisconnectSet();
+
 	UnregisterClassW(FtpClass, GetFtpInst());
 	FreeSSL();
 	FreeZoneID();

--- a/main.cpp
+++ b/main.cpp
@@ -507,9 +507,6 @@ static bool MakeAllWindows(int cmdShow) {
 
 	ShowWindow(GetMainHwnd(), cmdShow != SW_MINIMIZE && cmdShow != SW_SHOWMINIMIZED && cmdShow != SW_SHOWMINNOACTIVE && Sizing == SW_MAXIMIZE ? SW_MAXIMIZE : cmdShow);
 
-	if (MakeSocketWin() == FFFTP_FAIL)
-		return false;
-
 	SetListViewType();
 
 	return true;

--- a/remote.cpp
+++ b/remote.cpp
@@ -257,15 +257,6 @@ int DoQUOTE(std::shared_ptr<SocketContext> cSkt, std::wstring_view CmdStr, int* 
 }
 
 
-// ソケットを閉じる
-void DoClose(std::shared_ptr<SocketContext> Sock) {
-	if (Sock) {
-		Sock->Close();
-		Debug(L"Skt={} : Socket closed."sv, Sock->handle);
-	}
-}
-
-
 // ホストからログアウトする
 int DoQUIT(std::shared_ptr<SocketContext> ctrl_skt, int* CancelCheckWork) {
 	int Ret = FTP_COMPLETE;

--- a/socket.cpp
+++ b/socket.cpp
@@ -306,9 +306,12 @@ std::shared_ptr<SocketContext> SocketContext::Create(int af, std::variant<std::w
 SocketContext::SocketContext(SOCKET s, std::wstring originalTarget, std::wstring punyTarget) : WSAOVERLAPPED{}, handle { s }, originalTarget{ originalTarget }, punyTarget{ punyTarget } {}
 
 
-void SocketContext::Close() {
+SocketContext::~SocketContext() {
 	if (int result = closesocket(handle); result == SOCKET_ERROR)
 		WSAError(L"closesocket()"sv);
+	if (SecIsValidHandle(&sslContext))
+		DeleteSecurityContext(&sslContext);
+	Debug(L"Skt={} : Socket closed."sv, handle);
 }
 
 

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -71,7 +71,7 @@
     <CodeAnalysisRuleSet>../ffftp.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-    <IncludePath>$(VCInstallDir)UnitTest\include;../boost-regex/include;$(IncludePath)</IncludePath>
+    <IncludePath>$(VCInstallDir)UnitTest\include;../boost-regex/include;../gsl/include;$(IncludePath)</IncludePath>
     <LibraryPath>$(VCInstallDir)UnitTest\lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -80,7 +80,7 @@
     <CodeAnalysisRuleSet>../ffftp.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-    <IncludePath>$(VCInstallDir)UnitTest\include;../boost-regex/include;$(IncludePath)</IncludePath>
+    <IncludePath>$(VCInstallDir)UnitTest\include;../boost-regex/include;../gsl/include;$(IncludePath)</IncludePath>
     <LibraryPath>$(VCInstallDir)UnitTest\lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -89,7 +89,7 @@
     <CodeAnalysisRuleSet>../ffftp.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-    <IncludePath>$(VCInstallDir)UnitTest\include;../boost-regex/include;$(IncludePath)</IncludePath>
+    <IncludePath>$(VCInstallDir)UnitTest\include;../boost-regex/include;../gsl/include;$(IncludePath)</IncludePath>
     <LibraryPath>$(VCInstallDir)UnitTest\lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -98,7 +98,7 @@
     <CodeAnalysisRuleSet>../ffftp.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-    <IncludePath>$(VCInstallDir)UnitTest\include;../boost-regex/include;$(IncludePath)</IncludePath>
+    <IncludePath>$(VCInstallDir)UnitTest\include;../boost-regex/include;../gsl/include;$(IncludePath)</IncludePath>
     <LibraryPath>$(VCInstallDir)UnitTest\lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">


### PR DESCRIPTION
これまで`DoClose()`および`SocketContext::Close()`が存在していたが、呼び出しが不足すればsocket leak、複数回呼べばdouble-freeが発生する危うい実装であった。
これらの処理を`SocketContext`のデストラクタに移動することで、解放処理を確実に１回のみ実行する。

また、`SocketContext::Close()`ではソケット一覧を表す`map`を管理していたが、解放タイミングをデストラクタに任せると問題が発生する。ソケット一覧が必要となる理由は[`WSAAsyncSelect()`が使われている](https://github.com/ffftp/ffftp/issues/110)からであるが、これを`WSAEventSelect()`に移行する。
`WSAEventSelect()`に移行したことにより、メッセージループ依存が解消され、ソケット用Windowも不要となる。