### PR TITLE
コード改善

### DIFF
--- a/OleDragDrop.h
+++ b/OleDragDrop.h
@@ -172,7 +172,7 @@ namespace OleDragDrop {
 					return E_INVALIDARG;
 				if (dwDirection != DATADIR_GET)
 					return E_NOTIMPL;
-				return CreateFormatEnumerator(static_cast<UINT>(size(formatEtcs)), data(formatEtcs), ppenumFormatEtc);
+				return CreateFormatEnumerator(UINT(size(formatEtcs)), data(formatEtcs), ppenumFormatEtc);
 			}
 			STDMETHODIMP DAdvise(FORMATETC* pformatetc, DWORD advf, IAdviseSink* pAdvSink, DWORD* pdwConnection) override {
 				return OLE_E_ADVISENOTSUPPORTED;

--- a/common.h
+++ b/common.h
@@ -1258,23 +1258,16 @@ static auto ieq(std::wstring_view left, std::wstring_view right) {
 	return std::equal(begin(left), end(left), begin(right), end(right), [](auto const l, auto const r) { return std::towupper(l) == std::towupper(r); });
 }
 static inline auto lc(std::string&& str) {
-	_strlwr(data(str));
+	_strlwr_s(data(str), size(str) + 1);
 	return str;
 }
 static inline auto lc(std::wstring&& str) {
-	_wcslwr(data(str));
+	_wcslwr_s(data(str), size(str) + 1);
 	return str;
-}
-template<class String>
-static inline auto lc(String const& src) {
-	return lc(std::basic_string(std::begin(src), std::end(src)));
 }
 static inline auto uc(std::wstring&& str) {
-	_wcsupr(data(str));
+	_wcsupr_s(data(str), size(str) + 1);
 	return str;
-}
-static inline auto uc(std::wstring_view sv) {
-	return uc(std::wstring{ sv });
 }
 template<class Char, class Evaluator>
 static inline auto replace(std::basic_string_view<Char> input, boost::basic_regex<Char> const& pattern, Evaluator&& evaluator) {

--- a/common.h
+++ b/common.h
@@ -1099,7 +1099,6 @@ void SetOption();
 int SortSetting(void);
 // hostman.cで使用
 int GetDecimalText(HWND hDlg, int Ctrl);
-void CheckRange2(int *Cur, int Max, int Min);
 
 /*===== bookmark.c =====*/
 

--- a/common.h
+++ b/common.h
@@ -1200,7 +1200,7 @@ constexpr auto data_as(Source const& source) {
 }
 template<class Size, class Source>
 constexpr auto size_as(Source const& source) {
-	return static_cast<Size>(std::size(source));
+	return gsl::narrow_cast<Size>(std::size(source));
 }
 template<class T, class Allocator>
 constexpr auto before_end(std::forward_list<T, Allocator>& list) {
@@ -1321,7 +1321,7 @@ static inline void SetText(HWND hdlg, int id, const std::wstring& text) {
 static inline auto AddressPortToString(const SOCKADDR* sa, size_t salen) {
 	std::wstring string(sizeof "[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff%4294967295]:65535" - 1, L'\0');
 	auto length = size_as<DWORD>(string) + 1;
-	auto result = WSAAddressToStringW(const_cast<SOCKADDR*>(sa), static_cast<DWORD>(salen), nullptr, data(string), &length);
+	auto result = WSAAddressToStringW(const_cast<SOCKADDR*>(sa), gsl::narrow_cast<DWORD>(salen), nullptr, data(string), &length);
 	assert(result == 0);
 	string.resize(length - 1);
 	return string;

--- a/common.h
+++ b/common.h
@@ -1251,10 +1251,10 @@ static inline auto u8(const Char* str, size_t len) {
 	return u8(std::basic_string_view<Char>{ str, len });
 }
 static auto ieq(std::string_view left, std::string_view right) {
-	return std::equal(begin(left), end(left), begin(right), end(right), [](auto const l, auto const r) { return std::toupper(l) == std::toupper(r); });
+	return size(left) == size(right) && _strnicmp(data(left), data(right), size(left)) == 0;
 }
 static auto ieq(std::wstring_view left, std::wstring_view right) {
-	return std::equal(begin(left), end(left), begin(right), end(right), [](auto const l, auto const r) { return std::towupper(l) == std::towupper(r); });
+	return size(left) == size(right) && _wcsnicmp(data(left), data(right), size(left)) == 0;
 }
 static inline auto lc(std::string&& str) {
 	_strlwr_s(data(str), size(str) + 1);

--- a/common.h
+++ b/common.h
@@ -747,7 +747,6 @@ fs::path const& systemDirectory();
 fs::path const& tempDirectory();
 void DispWindowTitle();
 HWND GetMainHwnd(void);
-HWND GetFocusHwnd(void);
 void SetFocusHwnd(HWND hWnd);
 HINSTANCE GetFtpInst(void);
 void DoubleClickProc(int Win, int Mode, int App);

--- a/common.h
+++ b/common.h
@@ -902,7 +902,7 @@ static inline void WSAError(std::wstring_view functionName, int lastError = WSAG
 int SelectHost(int Type);
 int AddHostToList(HOSTDATA *Set, int Pos, int Level);
 int CopyHostFromList(int Num, HOSTDATA *Set);
-int CopyHostFromListInConnect(int Num, HOSTDATA *Set);
+HOSTDATA GetConnectingHost();
 int SetHostBookMark(int Num, std::vector<std::wstring>&& bookmark);
 std::optional<std::vector<std::wstring>> AskHostBookMark(int Num);
 int SetHostDir(int Num, std::wstring_view LocDir, std::wstring_view HostDir);
@@ -926,12 +926,6 @@ void ConnectProc(int Type, int Num);
 void QuickConnectProc(void);
 void DirectConnectProc(std::wstring&& unc, int Kanji, int Kana, int Fkanji, int TrMode);
 void HistoryConnectProc(int MenuCmd);
-int AskHostNameKana(void);
-int AskListCmdMode(void);
-int AskUseNLST_R(void);
-std::wstring AskHostChmodCmd();
-int AskHostTimeZone(void);
-std::wstring AskHostLsName();
 int AskHostType(void);
 int AskNoFullPathMode(void);
 void SaveCurrentSetToHost(void);
@@ -945,7 +939,6 @@ void DisconnectProc(void);
 void DisconnectSet(void);
 int AskConnecting(void);
 #if defined(HAVE_TANDEM)
-int AskRealHostType(void);
 int SetOSS(int wkOss);
 int AskOSS(void);
 #endif

--- a/common.h
+++ b/common.h
@@ -800,7 +800,7 @@ std::tuple<fs::path, std::vector<FILELIST>> MakeDroppedFileList(WPARAM wParam);
 fs::path MakeDroppedDir(WPARAM wParam);
 void AddRemoteTreeToFileList(int Num, std::wstring const& Path, int IncDir, std::vector<FILELIST>& Base);
 const FILELIST* SearchFileList(std::wstring_view Fname, std::vector<FILELIST> const& Base, int Caps);
-static inline FILELIST* SearchFileList(std::wstring_view Fname, std::vector<FILELIST>& Base, int Caps) {
+static inline FILELIST* SearchFileList(std::wstring_view Fname, __pragma(warning(suppress:26460)) std::vector<FILELIST>& Base, int Caps) {
 	return const_cast<FILELIST*>(SearchFileList(Fname, static_cast<std::vector<FILELIST> const&>(Base), Caps));
 }
 void SetFilter(int *CancelCheckWork);
@@ -1224,8 +1224,8 @@ template<class DstChar, class Fn>
 static inline auto convert(Fn&& fn, std::wstring_view src) {
 	return convert<DstChar, wchar_t>(std::forward<Fn>(fn), src);
 }
-template<class Char, class... Str>
-static inline auto concat(std::basic_string_view<Char> first, Str&&... rest) {
+template<class Char>
+static inline auto concat(std::basic_string_view<Char> first, auto const&... rest) {
 	std::basic_string<Char> result;
 	result.reserve((std::size(first) + ... + std::size(rest)));
 	((result += first) += ... += rest);

--- a/common.h
+++ b/common.h
@@ -27,7 +27,6 @@
 /============================================================================*/
 
 #pragma once
-#define _CRT_SECURE_NO_WARNINGS
 #define NOMINMAX
 #define SECURITY_WIN32
 #define WIN32_LEAN_AND_MEAN

--- a/common.h
+++ b/common.h
@@ -753,7 +753,6 @@ void DoubleClickProc(int Win, int Mode, int App);
 void ExecViewer(fs::path const& path, int App);
 void ExecViewer2(fs::path const& path1, fs::path const& path2, int App);
 void AddTempFileList(fs::path const& file);
-void SoundPlay(int Num);
 void ShowHelp(DWORD_PTR helpTopicId);
 fs::path const& AskIniFilePath();
 int AskForceIni(void);

--- a/common.h
+++ b/common.h
@@ -1150,7 +1150,6 @@ static std::wstring MakeSizeString(uintmax_t size) {
 	return std::format(L"{:0.1f}{}B"sv, (size >> 10 * i) / 1024., L"KMGTPE"[i]);
 }
 void DispStaticText(HWND hWnd, std::wstring text);
-void RectClientToScreen(HWND hWnd, RECT *Rect);
 fs::path SelectFile(bool open, HWND hWnd, UINT titleId, const wchar_t* initialFileName, const wchar_t* extension, std::initializer_list<FileType> fileTypes);
 fs::path SelectDir(HWND hWnd);
 fs::path MakeDistinguishableFileName(fs::path&& path);

--- a/connect.cpp
+++ b/connect.cpp
@@ -54,6 +54,7 @@ static int Oss = NO;  /* OSS ファイルシステムへアクセスしている
 
 
 // 接続しているホストを返す
+//   TODO: GetConnectingHost()との違いがよくわからない
 HOSTDATA const& GetCurHost() {
 	return CurHost;
 }
@@ -509,161 +510,16 @@ static void AskUseFireWall(std::wstring_view Host, int *Fire, int *Pasv, int *Li
 }
 
 
-/*----- 接続しているホストのファイル名の半角カナ変換フラグを返す --------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		int 半角カナを全角に変換するかどうか (YES/NO)
-*----------------------------------------------------------------------------*/
-
-int AskHostNameKana(void)
-{
-	// 同時接続対応
-	HOSTDATA TmpHost;
-	TmpHost = CurHost;
-
-	if(AskCurrentHost() != HOSTNUM_NOENTRY)
-		// 同時接続対応
-//		CopyHostFromListInConnect(AskCurrentHost(), &CurHost);
-		CopyHostFromListInConnect(AskCurrentHost(), &TmpHost);
-
-	// 同時接続対応
-//	return(CurHost.NameKanaCnv);
-	return(TmpHost.NameKanaCnv);
-}
-
-
-/*----- 接続しているホストのLISTコマンドモードを返す --------------------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		int LISTコマンドモード (YES/NO)
-*----------------------------------------------------------------------------*/
-
-int AskListCmdMode(void)
-{
-	// 同時接続対応
-	HOSTDATA TmpHost;
-	TmpHost = CurHost;
-
-	if(CurHost.HostType == HTYPE_VMS)
-		return(YES);
-	else
-	{
-		if(AskCurrentHost() != HOSTNUM_NOENTRY)
-			// 同時接続対応
-//			CopyHostFromListInConnect(AskCurrentHost(), &CurHost);
-			CopyHostFromListInConnect(AskCurrentHost(), &TmpHost);
-		// 同時接続対応
-//		return(CurHost.ListCmdOnly);
-		return(TmpHost.ListCmdOnly);
-	}
-}
-
-
-/*----- 接続しているホストでNLST -Rを使うかどうかを返す ------------------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		int NLST -Rを使うかどうか (YES/NO)
-*----------------------------------------------------------------------------*/
-
-int AskUseNLST_R(void)
-{
-	// 同時接続対応
-	HOSTDATA TmpHost;
-	TmpHost = CurHost;
-
-	if(AskCurrentHost() != HOSTNUM_NOENTRY)
-		// 同時接続対応
-//		CopyHostFromListInConnect(AskCurrentHost(), &CurHost);
-		CopyHostFromListInConnect(AskCurrentHost(), &TmpHost);
-
-	// 同時接続対応
-//	return(CurHost.UseNLST_R);
-	return(TmpHost.UseNLST_R);
-}
-
-
-std::wstring AskHostChmodCmd() {
-	HOSTDATA TmpHost = CurHost;
-	if (AskCurrentHost() != HOSTNUM_NOENTRY)
-		CopyHostFromListInConnect(AskCurrentHost(), &TmpHost);
-	return TmpHost.ChmodCmd;
-}
-
-
-/*----- 接続しているホストのタイムゾーンを返す --------------------------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		int タイムゾーン
-*----------------------------------------------------------------------------*/
-
-int AskHostTimeZone(void)
-{
-	// 同時接続対応
-	HOSTDATA TmpHost;
-	TmpHost = CurHost;
-
-	if(AskCurrentHost() != HOSTNUM_NOENTRY)
-		// 同時接続対応
-//		CopyHostFromListInConnect(AskCurrentHost(), &CurHost);
-		CopyHostFromListInConnect(AskCurrentHost(), &TmpHost);
-
-	// 同時接続対応
-//	return(CurHost.TimeZone);
-	return(TmpHost.TimeZone);
-}
-
-
-std::wstring AskHostLsName() {
-	HOSTDATA TmpHost = CurHost;
-	if (AskCurrentHost() != HOSTNUM_NOENTRY)
-		CopyHostFromListInConnect(AskCurrentHost(), &TmpHost);
-	return TmpHost.LsName;
-}
-
-
-/*----- 接続しているホストのホストタイプを返す --------------------------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		char *ファイル名／オプション
-*----------------------------------------------------------------------------*/
-
-int AskHostType(void)
-{
-	// 同時接続対応
-	HOSTDATA TmpHost;
-	TmpHost = CurHost;
-
-	if(AskCurrentHost() != HOSTNUM_NOENTRY)
-		// 同時接続対応
-//		CopyHostFromListInConnect(AskCurrentHost(), &CurHost);
-		CopyHostFromListInConnect(AskCurrentHost(), &TmpHost);
-
+// 接続しているホストのホストタイプを返す
+int AskHostType() {
 #if defined(HAVE_TANDEM)
 	/* OSS ファイルシステムは UNIX ファイルシステムと同じでいいので AUTO を返す
 	   ただし、Guardian ファイルシステムに戻ったときにおかしくならないように
 	   CurHost.HostType 変数は更新しない */
-	if(CurHost.HostType == HTYPE_TANDEM && Oss == YES)
-		return(HTYPE_AUTO);
+	if (CurHost.HostType == HTYPE_TANDEM && Oss == YES)
+		return HTYPE_AUTO;
 #endif
-
-	// 同時接続対応
-//	return(CurHost.HostType);
-	return(TmpHost.HostType);
+	return GetConnectingHost().HostType;
 }
 
 
@@ -685,38 +541,14 @@ int AskNoFullPathMode(void)
 }
 
 
-/*----- 現在の設定をホストの設定にセットする ----------------------------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		なし
-*
-*	Note
-*		カレントディレクトリ、ソート方法をホストの設定にセットする
-*----------------------------------------------------------------------------*/
-
-void SaveCurrentSetToHost(void)
-{
-	int Host;
-	// 同時接続対応
-	HOSTDATA TmpHost;
-	TmpHost = CurHost;
-
-	if (TrnCtrlSocket) {
-		if((Host = AskCurrentHost()) != HOSTNUM_NOENTRY)
-		{
-			// 同時接続対応
-//			CopyHostFromListInConnect(Host, &CurHost);
-//			if(CurHost.LastDir == YES)
-			CopyHostFromListInConnect(Host, &TmpHost);
-			if(TmpHost.LastDir == YES)
-				SetHostDir(AskCurrentHost(), AskLocalCurDir().native(), AskRemoteCurDir());
-			SetHostSort(AskCurrentHost(), AskSortType());
-		}
+// 現在の設定をホストの設定にセットする
+//   カレントディレクトリ、ソート方法をホストの設定にセットする
+void SaveCurrentSetToHost() {
+	if (TrnCtrlSocket && AskCurrentHost() != HOSTNUM_NOENTRY) {
+		if (GetConnectingHost().LastDir == YES)
+			SetHostDir(AskCurrentHost(), AskLocalCurDir().native(), AskRemoteCurDir());
+		SetHostSort(AskCurrentHost(), AskSortType());
 	}
-	return;
 }
 
 
@@ -917,31 +749,6 @@ int AskConnecting() {
 
 
 #if defined(HAVE_TANDEM)
-/*----- 接続している本当のホストのホストタイプを返す --------------------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		char *ファイル名／オプション
-*----------------------------------------------------------------------------*/
-
-int AskRealHostType(void)
-{
-	// 同時接続対応
-	HOSTDATA TmpHost;
-	TmpHost = CurHost;
-
-	if(AskCurrentHost() != HOSTNUM_NOENTRY)
-		// 同時接続対応
-//		CopyHostFromListInConnect(AskCurrentHost(), &CurHost);
-		CopyHostFromListInConnect(AskCurrentHost(), &TmpHost);
-
-	// 同時接続対応
-//	return(CurHost.HostType);
-	return(TmpHost.HostType);
-}
-
 /*----- OSS ファイルシステムにアクセスしているかどうかのフラグを変更する ------
 *
 *	Parameter

--- a/dialog.h
+++ b/dialog.h
@@ -120,7 +120,7 @@ namespace detail {
 			}
 			if constexpr (hasResizable<Data>()) {
 				if (uMsg == WM_SIZING) {
-					data->resizable.OnSizing(hwndDlg, reinterpret_cast<RECT*>(lParam), static_cast<int>(wParam));
+					data->resizable.OnSizing(hwndDlg, reinterpret_cast<RECT*>(lParam), int(wParam));
 					return TRUE;
 				}
 				if (uMsg == WM_SIZE) {

--- a/ffftp.ruleset
+++ b/ffftp.ruleset
@@ -11,7 +11,6 @@
     <Rule Id="C26429" Action="Hidden" />
     <Rule Id="C26432" Action="Hidden" />
     <Rule Id="C26436" Action="Hidden" />
-    <Rule Id="C26438" Action="Hidden" />
     <Rule Id="C26440" Action="Hidden" />
     <Rule Id="C26445" Action="Hidden" />
     <Rule Id="C26446" Action="Hidden" />

--- a/ffftp.ruleset
+++ b/ffftp.ruleset
@@ -19,7 +19,6 @@
     <Rule Id="C26459" Action="Hidden" />
     <Rule Id="C26461" Action="Hidden" />
     <Rule Id="C26462" Action="Hidden" />
-    <Rule Id="C26465" Action="Hidden" />
     <Rule Id="C26471" Action="Hidden" />
     <Rule Id="C26472" Action="Hidden" />
     <Rule Id="C26476" Action="Hidden" />

--- a/ffftp.ruleset
+++ b/ffftp.ruleset
@@ -16,7 +16,6 @@
     <Rule Id="C26446" Action="Hidden" />
     <Rule Id="C26447" Action="Hidden" />
     <Rule Id="C26455" Action="Hidden" />
-    <Rule Id="C26457" Action="Hidden" />
     <Rule Id="C26459" Action="Hidden" />
     <Rule Id="C26460" Action="Hidden" />
     <Rule Id="C26461" Action="Hidden" />

--- a/ffftp.ruleset
+++ b/ffftp.ruleset
@@ -5,7 +5,6 @@
     <!-- Bug of VS2022; https://developercommunity.visualstudio.com/t/Code-Analysis-crash/1559422 -->
     <Rule Id="C26800" Action="None" />
 
-    <Rule Id="C26410" Action="Hidden" />
     <Rule Id="C26415" Action="Hidden" />
     <Rule Id="C26418" Action="Hidden" />
     <Rule Id="C26426" Action="Hidden" />

--- a/ffftp.ruleset
+++ b/ffftp.ruleset
@@ -19,7 +19,6 @@
     <Rule Id="C26459" Action="Hidden" />
     <Rule Id="C26461" Action="Hidden" />
     <Rule Id="C26462" Action="Hidden" />
-    <Rule Id="C26471" Action="Hidden" />
     <Rule Id="C26472" Action="Hidden" />
     <Rule Id="C26476" Action="Hidden" />
     <Rule Id="C26481" Action="Hidden" />

--- a/ffftp.ruleset
+++ b/ffftp.ruleset
@@ -5,7 +5,6 @@
     <!-- Bug of VS2022; https://developercommunity.visualstudio.com/t/Code-Analysis-crash/1559422 -->
     <Rule Id="C26800" Action="None" />
 
-    <Rule Id="C26409" Action="Hidden" />
     <Rule Id="C26410" Action="Hidden" />
     <Rule Id="C26415" Action="Hidden" />
     <Rule Id="C26418" Action="Hidden" />

--- a/ffftp.ruleset
+++ b/ffftp.ruleset
@@ -17,7 +17,6 @@
     <Rule Id="C26447" Action="Hidden" />
     <Rule Id="C26455" Action="Hidden" />
     <Rule Id="C26459" Action="Hidden" />
-    <Rule Id="C26460" Action="Hidden" />
     <Rule Id="C26461" Action="Hidden" />
     <Rule Id="C26462" Action="Hidden" />
     <Rule Id="C26465" Action="Hidden" />

--- a/ffftp.ruleset
+++ b/ffftp.ruleset
@@ -19,7 +19,6 @@
     <Rule Id="C26459" Action="Hidden" />
     <Rule Id="C26461" Action="Hidden" />
     <Rule Id="C26462" Action="Hidden" />
-    <Rule Id="C26472" Action="Hidden" />
     <Rule Id="C26476" Action="Hidden" />
     <Rule Id="C26481" Action="Hidden" />
     <Rule Id="C26482" Action="Hidden" />

--- a/ffftp.ruleset
+++ b/ffftp.ruleset
@@ -29,7 +29,6 @@
     <Rule Id="C26493" Action="Hidden" />
     <Rule Id="C26494" Action="Hidden" />
     <Rule Id="C26496" Action="Hidden" />
-    <Rule Id="C26497" Action="Hidden" />
     <Rule Id="C26812" Action="Hidden" />
     <Rule Id="C26818" Action="Hidden" />
     <Rule Id="C26821" Action="Hidden" />

--- a/filelist.cpp
+++ b/filelist.cpp
@@ -1218,7 +1218,7 @@ int MakeSelectedFileList(int Win, int Expand, int All, std::vector<FILELIST>& Ba
 								Sts = FFFTP_FAIL;
 						} else {
 							auto const Cur = AskRemoteCurDir();
-							if (AskListCmdMode() == NO && AskUseNLST_R() == YES) {
+							if (auto const connectingHost = GetConnectingHost(); connectingHost.ListCmdOnly == NO && connectingHost.UseNLST_R == YES) {
 								if (MakeRemoteTree1(item.Name, Cur, Base, CancelCheckWork) == FFFTP_FAIL)
 									Sts = FFFTP_FAIL;
 							} else {
@@ -1530,7 +1530,7 @@ static int parseattr(boost::ssub_match const& m) {
 static inline FILETIME tofiletime(SYSTEMTIME const& systemTime, bool fix = false) {
 	FILETIME fileTime;
 	if (fix) {
-		TIME_ZONE_INFORMATION tz{ AskHostTimeZone() * -60 };
+		TIME_ZONE_INFORMATION tz{ GetConnectingHost().TimeZone * -60 };
 		SYSTEMTIME fixed;
 		TzSpecificLocalTimeToSystemTime(&tz, &systemTime, &fixed);
 		SystemTimeToFileTime(&fixed, &fileTime);
@@ -1600,7 +1600,7 @@ static std::optional<FILELIST> ParseUnix(boost::smatch const& m) {
 			infoExist |= FINFO_TIME;
 			SYSTEMTIME utcnow, localnow;
 			GetSystemTime(&utcnow);
-			TIME_ZONE_INFORMATION tz{ AskHostTimeZone() * -60 };
+			TIME_ZONE_INFORMATION tz{ GetConnectingHost().TimeZone * -60 };
 			SystemTimeToTzSpecificLocalTime(&tz, &utcnow, &localnow);
 			systemTime.wHour = parse<WORD>(m[8]);
 			systemTime.wMinute = parse<WORD>(m[9]);
@@ -1794,7 +1794,7 @@ static std::optional<FILELIST> Parse(std::string const& line) {
 		return boost::regex_search(line, m, re::shibasoku) ? ParseShibasoku(m) : std::nullopt;
 	}
 #if defined(HAVE_TANDEM)
-	if (AskRealHostType() == HTYPE_TANDEM)
+	if (GetConnectingHost().HostType == HTYPE_TANDEM)
 		SetOSS(YES);
 #endif
 	if (boost::regex_search(line, m, re::mlsd))

--- a/filelist.cpp
+++ b/filelist.cpp
@@ -319,7 +319,7 @@ static HDROP CreateDropFileMem(std::vector<fs::path> const& filenames) {
 	}
 	extra += L'\0';
 	if (auto drop = (HDROP)GlobalAlloc(GHND, sizeof(DROPFILES) + size(extra) * sizeof(wchar_t))) {
-		if (auto dropfiles = reinterpret_cast<DROPFILES*>(GlobalLock(drop))) {
+		if (auto dropfiles = static_cast<DROPFILES*>(GlobalLock(drop))) {
 			*dropfiles = { sizeof(DROPFILES), {}, false, true };
 			std::copy(begin(extra), end(extra), reinterpret_cast<wchar_t*>(dropfiles + 1));
 			GlobalUnlock(drop);

--- a/filelist.cpp
+++ b/filelist.cpp
@@ -1557,7 +1557,7 @@ static std::optional<FILELIST> ParseMlsd(boost::smatch const& m) {
 		auto factname = lc((*it)[1]);
 		auto value = sv((*it)[2]);
 		if (factname == "type"sv) {
-			if (auto lcvalue = lc(value); lcvalue == "dir"sv)
+			if (auto lcvalue = lc(std::string{ value }); lcvalue == "dir"sv)
 				type = NODE_DIR;
 			else if (lcvalue == "file"sv)
 				type = NODE_FILE;
@@ -1958,7 +1958,7 @@ static void AddFileList(FILELIST const& Pkt, std::vector<FILELIST>& Base) {
 
 const FILELIST* SearchFileList(std::wstring_view Fname, std::vector<FILELIST> const& Base, int Caps) {
 	for (auto p = data(Base), end = data(Base) + size(Base); p != end; ++p)
-		if (Caps == COMP_STRICT ? Fname == p->Name : ieq(Fname, p->Name) && (Caps == COMP_IGNORE || lc(p->Name) == p->Name))
+		if (Caps == COMP_STRICT ? Fname == p->Name : ieq(Fname, p->Name) && (Caps == COMP_IGNORE || lc(std::wstring{ p->Name }) == p->Name))
 			return p;
 	return nullptr;
 }

--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -134,7 +134,7 @@ void DownloadProc(int ChName, int ForceFile, int All)
 				AddTransFileList(&Pkt);
 			} else if (f.Node == NODE_FILE || ForceFile == YES && f.Node == NODE_DIR) {
 				Pkt.Remote
-					= AskHostType() == HTYPE_ACOS ? std::format(L"'{}({})'"sv, AskHostLsName(), f.Name)
+					= AskHostType() == HTYPE_ACOS ? std::format(L"'{}({})'"sv, GetConnectingHost().LsName, f.Name)
 					: AskHostType() == HTYPE_ACOS_4 ? f.Name
 					: ReplaceAll(SetSlashTail(std::wstring{ AskRemoteCurDir() }) + f.Name, L'\\', L'/');
 
@@ -220,7 +220,7 @@ void DirectDownloadProc(std::wstring_view Fname) {
 				Pkt.Local /= filename;
 
 				Pkt.Remote
-					= AskHostType() == HTYPE_ACOS ? std::format(L"'{}({})'"sv, AskHostLsName(), Fname)
+					= AskHostType() == HTYPE_ACOS ? std::format(L"'{}({})'"sv, GetConnectingHost().LsName, Fname)
 					: AskHostType() == HTYPE_ACOS_4 ? std::wstring{ Fname }
 					: ReplaceAll(SetSlashTail(std::wstring{ AskRemoteCurDir() }) + Fname, L'\\', L'/');
 
@@ -664,7 +664,7 @@ int MakeDirFromRemotePath(fs::path const& RemoteFile, fs::path const& Old, int F
 		Pkt.SecExt = DEF_SECEXT;
 		Pkt.MaxExt = DEF_MAXEXT;
 #endif
-		Pkt.Remote = AskHostType() == HTYPE_ACOS ? std::format(L"'{}({})'"sv, AskHostLsName(), name) : AskHostType() == HTYPE_ACOS_4 ? name : path.generic_wstring();
+		Pkt.Remote = AskHostType() == HTYPE_ACOS ? std::format(L"'{}({})'"sv, GetConnectingHost().LsName, name) : AskHostType() == HTYPE_ACOS_4 ? name : path.generic_wstring();
 		Pkt.Command = L"MKD "s;
 		Pkt.Local.clear();
 		AddTransFileList(&Pkt);
@@ -770,7 +770,7 @@ void UploadListProc(int ChName, int All)
 			Pkt.Remote = ReplaceAll(std::move(Pkt.Remote), L'\\', L'/');
 
 			if (AskHostType() == HTYPE_ACOS)
-				Pkt.Remote = std::format(L"'{}({})'"sv, AskHostLsName(), std::wstring_view{ Pkt.Remote }.substr(offset));
+				Pkt.Remote = std::format(L"'{}({})'"sv, GetConnectingHost().LsName, std::wstring_view{ Pkt.Remote }.substr(offset));
 			else if (AskHostType() == HTYPE_ACOS_4)
 				Pkt.Remote = Pkt.Remote.substr(offset);
 
@@ -903,7 +903,7 @@ void UploadDragProc(WPARAM wParam)
 		for (auto const& f : files) {
 			auto Cat = RemoteName(std::wstring{ f.Name });
 			Pkt.Remote
-				= AskHostType() == HTYPE_ACOS ? std::format(L"'{}({})'"sv, AskHostLsName(), Cat)
+				= AskHostType() == HTYPE_ACOS ? std::format(L"'{}({})'"sv, GetConnectingHost().LsName, Cat)
 				: AskHostType() == HTYPE_ACOS_4 ? std::move(Cat)
 				: ReplaceAll(SetSlashTail(std::wstring{ AskRemoteCurDir() }) + Cat, L'\\', L'/');
 #if defined(HAVE_TANDEM)

--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -446,7 +446,7 @@ void MirrorDownloadProc(int Notify)
 					Pkt.Local = AskLocalCurDir();
 					auto name = f.Name;
 					if (MirrorFnameCnv == YES)
-						name = lc(name);
+						name = lc(std::move(name));
 					Pkt.Local /= RemoveAfterSemicolon(std::move(name));
 
 					if (f.Node == NODE_DIR) {
@@ -1148,7 +1148,7 @@ void MirrorUploadProc(int Notify)
 
 			for (auto const& f : LocalListBase) {
 				if (f.Attr == YES) {
-					auto Cat = MirrorFnameCnv == YES ? lc(f.Name) : f.Name;
+					auto Cat = MirrorFnameCnv == YES ? lc(std::wstring{ f.Name }) : f.Name;
 					Pkt.Remote = ReplaceAll(SetSlashTail(std::wstring{ AskRemoteCurDir() }) + Cat, L'\\', L'/');
 
 					if (f.Node == NODE_DIR) {

--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -2146,7 +2146,7 @@ void CopyURLtoClipBoard() {
 		if (EmptyClipboard())
 			if (auto global = GlobalAlloc(GHND, (size_as<SIZE_T>(text) + 1) * sizeof(wchar_t)); global)
 				if (auto buffer = GlobalLock(global); buffer) {
-					std::copy(begin(text), end(text), reinterpret_cast<wchar_t*>(buffer));
+					std::copy(begin(text), end(text), static_cast<wchar_t*>(buffer));
 					GlobalUnlock(global);
 					SetClipboardData(CF_UNICODETEXT, global);
 				}

--- a/getput.cpp
+++ b/getput.cpp
@@ -123,7 +123,7 @@ static int TransferErrorDisplay = 0;
 
 static void SetErrorMsg(std::wstring&& msg) {
 	if (empty(ErrMsg))
-		ErrMsg = msg;
+		ErrMsg = std::move(msg);
 }
 
 

--- a/getput.cpp
+++ b/getput.cpp
@@ -532,7 +532,7 @@ static unsigned __stdcall TransferThread(void *Dummy)
 						/* ここではエラーチェックはしない */
 
 					if(FolderAttr)
-						Command(TrnSkt, &Canceled[Pos->ThreadCount], L"{} {:03d} {}"sv, AskHostChmodCmd(), FolderAttrNum, dir);
+						Command(TrnSkt, &Canceled[Pos->ThreadCount], L"{} {:03d} {}"sv, GetConnectingHost().ChmodCmd, FolderAttrNum, dir);
 					}
 				} else if (!Pos->Local.empty()) {
 					Down = YES;
@@ -551,7 +551,7 @@ static unsigned __stdcall TransferThread(void *Dummy)
 					Command(TrnSkt, &Canceled[Pos->ThreadCount], L"{}{}"sv, std::wstring_view{ Pos->Command }.substr(2), Pos->Remote);
 
 					if(FolderAttr)
-						Command(TrnSkt, &Canceled[Pos->ThreadCount], L"{} {:03d} {}"sv, AskHostChmodCmd(), FolderAttrNum, Pos->Remote);
+						Command(TrnSkt, &Canceled[Pos->ThreadCount], L"{} {:03d} {}"sv, GetConnectingHost().ChmodCmd, FolderAttrNum, Pos->Remote);
 				}
 			}
 			/* ディレクトリ削除（常にホスト側） */
@@ -1221,7 +1221,7 @@ static int DoUpload(std::shared_ptr<SocketContext> cSkt, TRANSPACKET& item)
 
 			/* 属性変更 */
 			if((item.Attr != -1) && ((iRetCode/100) == FTP_COMPLETE))
-				Command(item.ctrl_skt, &Canceled[item.ThreadCount], L"{} {:03X} {}"sv, AskHostChmodCmd(), item.Attr, item.Remote);
+				Command(item.ctrl_skt, &Canceled[item.ThreadCount], L"{} {:03X} {}"sv, GetConnectingHost().ChmodCmd, item.Attr, item.Remote);
 		}
 		else
 		{

--- a/hostman.cpp
+++ b/hostman.cpp
@@ -1165,11 +1165,9 @@ struct Feature {
 	static INT_PTR OnNotify(HWND hDlg, NMHDR* nmh) {
 		switch (nmh->code) {
 		case PSN_APPLY:
-			TmpHost.MaxThreadCount = GetDecimalText(hDlg, HSET_THREAD_COUNT);
-			CheckRange2(&TmpHost.MaxThreadCount, MAX_DATA_CONNECTION, 1);
+			TmpHost.MaxThreadCount = std::clamp(GetDecimalText(hDlg, HSET_THREAD_COUNT), 1, MAX_DATA_CONNECTION);
 			TmpHost.ReuseCmdSkt = (int)SendDlgItemMessageW(hDlg, HSET_REUSE_SOCKET, BM_GETCHECK, 0, 0);
-			TmpHost.NoopInterval = GetDecimalText(hDlg, HSET_NOOP_INTERVAL);
-			CheckRange2(&TmpHost.NoopInterval, 300, 0);
+			TmpHost.NoopInterval = std::clamp(GetDecimalText(hDlg, HSET_NOOP_INTERVAL), 0, 300);
 			switch (SendDlgItemMessageW(hDlg, HSET_ERROR_MODE, CB_GETCURSEL, 0, 0)) {
 			case 0:
 				TmpHost.TransferErrorMode = EXIST_OVW;

--- a/hostman.cpp
+++ b/hostman.cpp
@@ -547,7 +547,7 @@ static void DeleteChildAndNext(std::shared_ptr<HOSTLISTDATA> Pos) {
 
 
 // 設定値リストから設定値を取り出す
-//   現在ホストに接続中の時は、CopyHostFromListInConnect() を使う事
+//   現在ホストに接続中の時は、GetConnectingHost() を使う事
 int CopyHostFromList(int Num, HOSTDATA* Set) {
 	if (Num < 0 || Hosts <= Num)
 		return FFFTP_FAIL;
@@ -557,38 +557,37 @@ int CopyHostFromList(int Num, HOSTDATA* Set) {
 }
 
 
-// 設定値リストから設定値を取り出す
-//   現在ホストに接続中の時に使う
-int CopyHostFromListInConnect(int Num, HOSTDATA* Set) {
-	if (Num < 0 || Hosts <= Num)
-		return FFFTP_FAIL;
-	auto Pos = GetNode(Num);
-	Set->ChmodCmd = Pos->ChmodCmd;
-	Set->Port = Pos->Port;
-	Set->Anonymous = Pos->Anonymous;
-	Set->KanjiCode = Pos->KanjiCode;
-	Set->KanaCnv = Pos->KanaCnv;
-	Set->NameKanjiCode = Pos->NameKanjiCode;
-	Set->NameKanaCnv = Pos->NameKanaCnv;
-	Set->Pasv = Pos->Pasv;
-	Set->FireWall = Pos->FireWall;
-	Set->ListCmdOnly = Pos->ListCmdOnly;
-	Set->UseNLST_R = Pos->UseNLST_R;
-	Set->LastDir = Pos->LastDir;
-	Set->TimeZone = Pos->TimeZone;
-	Set->UseNoEncryption = Pos->UseNoEncryption;
-	Set->UseFTPES = Pos->UseFTPES;
-	Set->UseFTPIS = Pos->UseFTPIS;
-	Set->UseSFTP = Pos->UseSFTP;
-	Set->MaxThreadCount = Pos->MaxThreadCount;
-	Set->ReuseCmdSkt = Pos->ReuseCmdSkt;
-	Set->UseMLSD = Pos->UseMLSD;
-	Set->NoopInterval = Pos->NoopInterval;
-	Set->TransferErrorMode = Pos->TransferErrorMode;
-	Set->TransferErrorNotify = Pos->TransferErrorNotify;
-	Set->TransferErrorReconnect = Pos->TransferErrorReconnect;
-	Set->NoPasvAdrs = Pos->NoPasvAdrs;
-	return FFFTP_SUCCESS;
+HOSTDATA GetConnectingHost() {
+	auto host = GetCurHost();
+	if (0 <= ConnectingHost && ConnectingHost < Hosts) {
+		auto pos = GetNode(ConnectingHost);
+		host.ChmodCmd = pos->ChmodCmd;
+		host.Port = pos->Port;
+		host.Anonymous = pos->Anonymous;
+		host.KanjiCode = pos->KanjiCode;
+		host.KanaCnv = pos->KanaCnv;
+		host.NameKanjiCode = pos->NameKanjiCode;
+		host.NameKanaCnv = pos->NameKanaCnv;
+		host.Pasv = pos->Pasv;
+		host.FireWall = pos->FireWall;
+		host.ListCmdOnly = pos->ListCmdOnly;
+		host.UseNLST_R = pos->UseNLST_R;
+		host.LastDir = pos->LastDir;
+		host.TimeZone = pos->TimeZone;
+		host.UseNoEncryption = pos->UseNoEncryption;
+		host.UseFTPES = pos->UseFTPES;
+		host.UseFTPIS = pos->UseFTPIS;
+		host.UseSFTP = pos->UseSFTP;
+		host.MaxThreadCount = pos->MaxThreadCount;
+		host.ReuseCmdSkt = pos->ReuseCmdSkt;
+		host.UseMLSD = pos->UseMLSD;
+		host.NoopInterval = pos->NoopInterval;
+		host.TransferErrorMode = pos->TransferErrorMode;
+		host.TransferErrorNotify = pos->TransferErrorNotify;
+		host.TransferErrorReconnect = pos->TransferErrorReconnect;
+		host.NoPasvAdrs = pos->NoPasvAdrs;
+	}
+	return host;
 }
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -1660,7 +1660,7 @@ void DoubleClickProc(int Win, int Mode, int App) {
 							SktShareProh();
 
 						MainTransPkt.Command = L"RETR "s;
-						MainTransPkt.Remote = AskHostType() == HTYPE_ACOS ? std::format(L"'{}({})'"sv, AskHostLsName(), item.Name) : item.Name;
+						MainTransPkt.Remote = AskHostType() == HTYPE_ACOS ? std::format(L"'{}({})'"sv, GetConnectingHost().LsName, item.Name) : item.Name;
 						MainTransPkt.Local = remotePath;
 						MainTransPkt.Type = AskTransferTypeAssoc(MainTransPkt.Remote, AskTransferType());
 						MainTransPkt.Size = 1;

--- a/main.cpp
+++ b/main.cpp
@@ -1573,7 +1573,7 @@ static std::optional<int> AnalyzeComLine(std::vector<std::wstring_view> const& a
 	int option = 0;
 	for (auto it = begin(args); it != end(args); ++it) {
 		if ((*it)[0] == L'-') {
-			auto key = lc(*it);
+			auto key = lc(std::wstring{ *it });
 			if (auto mapit = map.find(key); mapit != end(map)) {
 				option |= mapit->second;
 			} else if (key == L"-n"sv || key == L"--ini"sv) {

--- a/main.cpp
+++ b/main.cpp
@@ -538,34 +538,9 @@ HWND GetMainHwnd() {
 }
 
 
-/*----- 現在フォーカスがあるウインドウのウインドウハンドルを返す --------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		HWND ウインドウハンドル
-*----------------------------------------------------------------------------*/
-
-HWND GetFocusHwnd(void)
-{
-	return(hWndCurFocus);
-}
-
-
-/*----- 現在フォーカスがあるウインドウのをセットする --------------------------
-*
-*	Parameter
-*		HWND hWnd : ウインドウハンドル
-*
-*	Return Value
-*		なし
-*----------------------------------------------------------------------------*/
-
-void SetFocusHwnd(HWND hWnd)
-{
+// 現在フォーカスがあるウインドウのをセットする
+void SetFocusHwnd(HWND hWnd) {
 	hWndCurFocus = hWnd;
-	return;
 }
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -166,7 +166,7 @@ static auto version() {
 	UINT len;
 	result = VerQueryValueW(data(buffer), L"\\", &block, &len);
 	assert(result && sizeof(VS_FIXEDFILEINFO) <= len);
-	auto const ms = reinterpret_cast<VS_FIXEDFILEINFO*>(block)->dwProductVersionMS, ls = reinterpret_cast<VS_FIXEDFILEINFO*>(block)->dwProductVersionLS;
+	auto const ms = static_cast<VS_FIXEDFILEINFO*>(block)->dwProductVersionMS, ls = static_cast<VS_FIXEDFILEINFO*>(block)->dwProductVersionLS;
 	auto const major = HIWORD(ms), minor = LOWORD(ms), patch = HIWORD(ls), build = LOWORD(ls);
 	auto const format = build != 0 ? L"{}.{}.{}.{}"sv : patch != 0 ? L"{}.{}.{}"sv : L"{}.{}"sv;
 	return std::format(format, major, minor, patch, build);

--- a/misc.cpp
+++ b/misc.cpp
@@ -111,36 +111,6 @@ void DispStaticText(HWND hWnd, std::wstring text) {
 }
 
 
-/*----- RECTをクライアント座標からスクリーン座標に変換 ------------------------
-*
-*	Parameter
-*		HWND hWnd : ウインドウハンドル
-*		RECT *Rect : RECT
-*
-*	Return Value
-*		なし
-*----------------------------------------------------------------------------*/
-
-void RectClientToScreen(HWND hWnd, RECT *Rect)
-{
-	POINT Tmp;
-
-	Tmp.x = Rect->left;
-	Tmp.y = Rect->top;
-	ClientToScreen(hWnd, &Tmp);
-	Rect->left = Tmp.x;
-	Rect->top = Tmp.y;
-
-	Tmp.x = Rect->right;
-	Tmp.y = Rect->bottom;
-	ClientToScreen(hWnd, &Tmp);
-	Rect->right = Tmp.x;
-	Rect->bottom = Tmp.y;
-
-	return;
-}
-
-
 static auto GetFilterString(std::initializer_list<FileType> fileTypes) {
 	static auto const map = [] {
 		std::map<FileType, std::wstring> map;

--- a/misc.cpp
+++ b/misc.cpp
@@ -161,7 +161,7 @@ static auto GetFilterString(std::initializer_list<FileType> fileTypes) {
 fs::path SelectFile(bool open, HWND hWnd, UINT titleId, const wchar_t* initialFileName, const wchar_t* extension, std::initializer_list<FileType> fileTypes) {
 	auto const filter = GetFilterString(fileTypes);
 	wchar_t buffer[FMAX_PATH + 1];
-	wcscpy(buffer, initialFileName);
+	wcscpy_s(buffer, initialFileName);
 	auto const title = GetString(titleId);
 	DWORD flags = (open ? OFN_FILEMUSTEXIST : OFN_EXTENSIONDIFFERENT | OFN_OVERWRITEPROMPT) | OFN_HIDEREADONLY | OFN_PATHMUSTEXIST;
 	OPENFILENAMEW ofn{ sizeof(OPENFILENAMEW), hWnd, 0, filter.c_str(), nullptr, 0, 1, buffer, size_as<DWORD>(buffer), nullptr, 0, nullptr, title.c_str(), flags, 0, 0, extension };

--- a/misc.cpp
+++ b/misc.cpp
@@ -51,7 +51,7 @@ std::wstring ReplaceAll(std::wstring&& str, wchar_t from, wchar_t to) {
 	if (!empty(str)) {
 		auto it = begin(str);
 #if defined(HAVE_TANDEM)
-		if (AskRealHostType() == HTYPE_TANDEM)
+		if (GetConnectingHost().HostType == HTYPE_TANDEM)
 			++it;
 #endif
 		std::replace(it, end(str), from, to);

--- a/option.cpp
+++ b/option.cpp
@@ -48,7 +48,6 @@ static void SetStrings(HWND hdlg, int id, std::vector<std::wstring> const& strin
 		SendDlgItemMessageW(hdlg, id, LB_ADDSTRING, 0, (LPARAM)string.c_str());
 }
 int GetDecimalText(HWND hDlg, int Ctrl);
-void CheckRange2(int *Cur, int Max, int Min);
 
 
 // ファイル属性設定ウインドウ
@@ -177,8 +176,7 @@ struct Transfer2 {
 		case PSN_APPLY: {
 			DefaultLocalPath = GetText(hDlg, TRMODE2_LOCAL);
 			FnameCnv = CnvButton::Get(hDlg);
-			TimeOut = GetDecimalText(hDlg, TRMODE2_TIMEOUT);
-			CheckRange2(&TimeOut, 300, 0);
+			TimeOut = std::clamp(GetDecimalText(hDlg, TRMODE2_TIMEOUT), 0, 300);
 			return PSNRET_NOERROR;
 		}
 		case PSN_HELP:
@@ -489,8 +487,7 @@ struct Connecting {
 			ConnectAndSet = (int)SendDlgItemMessageW(hDlg, MISC_OLDDLG, BM_GETCHECK, 0, 0);
 			RasClose = (int)SendDlgItemMessageW(hDlg, CONNECT_RASCLOSE, BM_GETCHECK, 0, 0);
 			RasCloseNotify = (int)SendDlgItemMessageW(hDlg, CONNECT_CLOSE_NOTIFY, BM_GETCHECK, 0, 0);
-			FileHist = GetDecimalText(hDlg, CONNECT_HIST);
-			CheckRange2(&FileHist, HISTORY_MAX, 0);
+			FileHist = std::clamp(GetDecimalText(hDlg, CONNECT_HIST), 0, HISTORY_MAX);
 			QuickAnonymous = (int)SendDlgItemMessageW(hDlg, CONNECT_QUICK_ANONY, BM_GETCHECK, 0, 0);
 			PassToHist = (int)SendDlgItemMessageW(hDlg, CONNECT_HIST_PASS, BM_GETCHECK, 0, 0);
 			SendQuit = (int)SendDlgItemMessageW(hDlg, CONNECT_SENDQUIT, BM_GETCHECK, 0, 0);
@@ -751,30 +748,4 @@ int SortSetting() {
 int GetDecimalText(HWND hDlg, int Ctrl) {
 	auto const text = GetText(hDlg, Ctrl);
 	return !empty(text) && std::iswdigit(text[0]) ? stoi(text) : 0;
-}
-
-
-/*----- 設定値の範囲チェック --------------------------------------------------
-*
-*	Parameter
-*		int *Cur : 設定値
-*		int Max : 最大値
-*		int Min : 最小値
-*
-*	Return Value
-*		なし
-*
-*	Parameter change
-*		int *Cur : 設定値
-*----------------------------------------------------------------------------*/
-
-// hostman.cで使用
-//static void CheckRange2(int *Cur, int Max, int Min)
-void CheckRange2(int *Cur, int Max, int Min)
-{
-	if(*Cur < Min)
-		*Cur = Min;
-	if(*Cur > Max)
-		*Cur = Max;
-	return;
 }

--- a/registry.cpp
+++ b/registry.cpp
@@ -847,7 +847,7 @@ void Config::WritePassword(std::string_view name, std::wstring_view password) {
 struct IniConfig : Config {
 	std::shared_ptr<std::map<std::string, std::vector<std::string>>> map;
 	bool const update;
-	IniConfig(std::string const& keyName, bool update) : Config{ keyName }, map{ new std::map<std::string, std::vector<std::string>>{} }, update{ update } {}
+	IniConfig(std::string const& keyName, bool update) : Config{ keyName }, map{ std::make_shared<std::map<std::string, std::vector<std::string>>>() }, update{ update } {}
 	IniConfig(std::string const& keyName, IniConfig& parent) : Config{ keyName }, map{ parent.map }, update{ false } {}
 	~IniConfig() override {
 		if (update) {

--- a/registry.cpp
+++ b/registry.cpp
@@ -1075,7 +1075,7 @@ void Config::Xor(std::string_view name, void* bin, DWORD len, bool preserveZero)
 		return;
 	auto result = HashOpen(BCRYPT_SHA1_ALGORITHM, [bin, len, preserveZero, salt = KeyName + '\\' + name](auto alg, auto obj, auto hash) {
 		assert(hash.size() == 20);
-		auto p = reinterpret_cast<BYTE*>(bin);
+		auto p = static_cast<BYTE*>(bin);
 		for (DWORD i = 0; i < len; i++) {
 			if (i % 20 == 0) {
 				std::array<DWORD, 16> buffer;

--- a/registry.cpp
+++ b/registry.cpp
@@ -75,7 +75,7 @@ public:
 	bool ReadValue(std::string_view name, Integral& value) const {
 		static_assert(sizeof(Integral) <= sizeof(int));
 		if (int temp; ReadValue(name, temp)) {
-			value = static_cast<Integral>(temp);
+			value = gsl::narrow_cast<Integral>(temp);
 			return true;
 		}
 		return false;

--- a/registry.cpp
+++ b/registry.cpp
@@ -167,13 +167,13 @@ public:
 	bool ReadFont(std::string_view name, HFONT& hfont, LOGFONTW& logfont) {
 		if (std::wstring value; ReadValue(name, value)) {
 			int offset;
-			auto read = swscanf(value.c_str(), L"%ld %ld %ld %ld %ld %hhu %hhu %hhu %hhu %hhu %hhu %hhu %hhu %n",
+			auto read = swscanf_s(value.c_str(), L"%ld %ld %ld %ld %ld %hhu %hhu %hhu %hhu %hhu %hhu %hhu %hhu %n",
 				&logfont.lfHeight, &logfont.lfWidth, &logfont.lfEscapement, &logfont.lfOrientation, &logfont.lfWeight,
 				&logfont.lfItalic, &logfont.lfUnderline, &logfont.lfStrikeOut, &logfont.lfCharSet,
 				&logfont.lfOutPrecision, &logfont.lfClipPrecision, &logfont.lfQuality, &logfont.lfPitchAndFamily, &offset
 			);
 			if (read == 13) {
-				wcscpy(logfont.lfFaceName, value.c_str() + offset);
+				wcscpy_s(logfont.lfFaceName, value.c_str() + offset);
 				hfont = CreateFontIndirectW(&logfont);
 				return true;
 			}

--- a/remote.cpp
+++ b/remote.cpp
@@ -232,7 +232,7 @@ int DoMDTM(std::shared_ptr<SocketContext> cSkt, std::wstring const& Path, FILETI
 		std::wstring text;
 		std::tie(code, text) = Command(cSkt, CancelCheckWork, L"MDTM {}"sv, Path);
 		if (code / 100 == FTP_COMPLETE)
-			if (SYSTEMTIME st{}; swscanf(&text[4], L"%04hu%02hu%02hu%02hu%02hu%02hu", &st.wYear, &st.wMonth, &st.wDay, &st.wHour, &st.wMinute, &st.wSecond) == 6)
+			if (SYSTEMTIME st{}; swscanf_s(&text[4], L"%04hu%02hu%02hu%02hu%02hu%02hu", &st.wYear, &st.wMonth, &st.wDay, &st.wHour, &st.wMinute, &st.wSecond) == 6)
 				SystemTimeToFileTime(&st, Time);
 	}
 	return code / 100;

--- a/socket.cpp
+++ b/socket.cpp
@@ -146,8 +146,7 @@ enum class CertResult {
 
 struct CertDialog {
 	using result_t = int;
-	std::unique_ptr<CERT_CONTEXT> const& certContext;
-	CertDialog(std::unique_ptr<CERT_CONTEXT> const& certContext) : certContext{ certContext } {}
+	CERT_CONTEXT* const certContext;
 	void OnCommand(HWND hdlg, WORD commandId) {
 		switch (commandId) {
 		case IDYES:
@@ -155,7 +154,7 @@ struct CertDialog {
 			EndDialog(hdlg, commandId);
 			break;
 		case IDC_SHOWCERT:
-			CRYPTUI_VIEWCERTIFICATE_STRUCTW certViewInfo{ sizeof CRYPTUI_VIEWCERTIFICATE_STRUCTW, hdlg, CRYPTUI_DISABLE_EDITPROPERTIES | CRYPTUI_DISABLE_ADDTOSTORE, nullptr, certContext.get() };
+			CRYPTUI_VIEWCERTIFICATE_STRUCTW certViewInfo{ sizeof CRYPTUI_VIEWCERTIFICATE_STRUCTW, hdlg, CRYPTUI_DISABLE_EDITPROPERTIES | CRYPTUI_DISABLE_ADDTOSTORE, nullptr, certContext };
 			__pragma(warning(suppress:6387)) CryptUIDlgViewCertificateW(&certViewInfo, nullptr);
 			break;
 		}
@@ -192,7 +191,7 @@ static CertResult ConfirmSSLCertificate(CtxtHandle& context, wchar_t* serverName
 	if (std::find(begin(acceptedThumbprints), end(acceptedThumbprints), thumbprint) != end(acceptedThumbprints))
 		return CertResult::NotSecureAccepted;
 
-	if (Dialog(GetFtpInst(), certerr_dlg, GetMainHwnd(), CertDialog{ certContext }) == IDYES) {
+	if (Dialog(GetFtpInst(), certerr_dlg, GetMainHwnd(), CertDialog{ certContext.get() }) == IDYES) {
 		acceptedThumbprints.push_back(thumbprint);
 		return CertResult::NotSecureAccepted;
 	}

--- a/socket.cpp
+++ b/socket.cpp
@@ -77,7 +77,7 @@ BOOL LoadSSL() {
 	//   排他となるプロトコルがあるため、有効になっているプロトコルのうちSSL 3.0以降とTLS 1.2を指定してオープンする。
 	//   セッション再開が必要とされるため、TLS 1.3は明示的には有効化せず、レジストリ指定に従う。
 	static_assert(SP_PROT_TLS1_3PLUS_CLIENT == SP_PROT_TLS1_3_CLIENT, "new tls version detected.");
-	if (auto ss = AcquireCredentialsHandleW(nullptr, const_cast<wchar_t*>(UNISP_NAME_W), SECPKG_CRED_OUTBOUND, nullptr, nullptr, nullptr, nullptr, &credential, nullptr); ss != SEC_E_OK) {
+	if (auto ss = AcquireCredentialsHandleW(nullptr, __pragma(warning(suppress:26465)) const_cast<wchar_t*>(UNISP_NAME_W), SECPKG_CRED_OUTBOUND, nullptr, nullptr, nullptr, nullptr, &credential, nullptr); ss != SEC_E_OK) {
 		Error(L"AcquireCredentialsHandle()"sv, ss);
 		return FALSE;
 	}
@@ -91,7 +91,7 @@ BOOL LoadSSL() {
 		// pAuthDataはSCHANNEL_CREDからSCH_CREDENTIALSに変更されたが現状維持する。
 		// https://github.com/MicrosoftDocs/win32/commit/e9f333c14bad8fd65d89ccc64d42882bc5fa7d9c
 		SCHANNEL_CRED sc{ .dwVersion = SCHANNEL_CRED_VERSION, .grbitEnabledProtocols = sp.grbitProtocol & SP_PROT_SSL3TLS1_X_CLIENTS | SP_PROT_TLS1_2_CLIENT };
-		if (auto ss = AcquireCredentialsHandleW(nullptr, const_cast<wchar_t*>(UNISP_NAME_W), SECPKG_CRED_OUTBOUND, nullptr, &sc, nullptr, nullptr, &credential, nullptr); ss != SEC_E_OK) {
+		if (auto ss = AcquireCredentialsHandleW(nullptr, __pragma(warning(suppress:26465)) const_cast<wchar_t*>(UNISP_NAME_W), SECPKG_CRED_OUTBOUND, nullptr, &sc, nullptr, nullptr, &credential, nullptr); ss != SEC_E_OK) {
 			Error(L"AcquireCredentialsHandle()"sv, ss);
 			return FALSE;
 		}

--- a/socket.cpp
+++ b/socket.cpp
@@ -237,7 +237,7 @@ BOOL SocketContext::AttachSSL(BOOL* pbAborted) {
 	if (sslReadStatus != SEC_I_CONTINUE_NEEDED)
 		return FALSE;
 	assert(outBuffer[0].BufferType == SECBUFFER_TOKEN && outBuffer[0].cbBuffer != 0 && outBuffer[0].pvBuffer != nullptr);
-	auto written = send(handle, reinterpret_cast<const char*>(outBuffer[0].pvBuffer), outBuffer[0].cbBuffer, 0);
+	auto written = send(handle, static_cast<const char*>(outBuffer[0].pvBuffer), outBuffer[0].cbBuffer, 0);
 	_RPTWN(_CRT_WARN, L"SC{%zu}: send(): %d.\n", handle, written);
 	assert(written == outBuffer[0].cbBuffer);
 	__pragma(warning(suppress:6387)) FreeContextBuffer(outBuffer[0].pvBuffer);
@@ -434,7 +434,7 @@ void SocketContext::OnComplete(DWORD error, DWORD transferred, DWORD flags) {
 			if (sslReadStatus == SEC_E_OK || sslReadStatus == SEC_I_CONTINUE_NEEDED) {
 				if (outBuffer[0].BufferType == SECBUFFER_TOKEN && outBuffer[0].cbBuffer != 0) {
 					// TODO: 送信バッファが埋まっている場合に失敗する
-					auto written = send(handle, reinterpret_cast<const char*>(outBuffer[0].pvBuffer), outBuffer[0].cbBuffer, 0);
+					auto written = send(handle, static_cast<const char*>(outBuffer[0].pvBuffer), outBuffer[0].cbBuffer, 0);
 					_RPTWN(_CRT_WARN, L"SC{%zu}: send(): %d.\n", handle, written);
 					assert(written == outBuffer[0].cbBuffer);
 					FreeContextBuffer(outBuffer[0].pvBuffer);
@@ -463,7 +463,7 @@ void SocketContext::OnComplete(DWORD error, DWORD transferred, DWORD flags) {
 			);
 			if (sslReadStatus == SEC_E_OK) {
 				assert(buffer[0].BufferType == SECBUFFER_STREAM_HEADER && buffer[1].BufferType == SECBUFFER_DATA && buffer[2].BufferType == SECBUFFER_STREAM_TRAILER);
-				readPlain.insert(end(readPlain), reinterpret_cast<const char*>(buffer[1].pvBuffer), reinterpret_cast<const char*>(buffer[1].pvBuffer) + buffer[1].cbBuffer);
+				readPlain.insert(end(readPlain), static_cast<const char*>(buffer[1].pvBuffer), static_cast<const char*>(buffer[1].pvBuffer) + buffer[1].cbBuffer);
 				readRaw.erase(begin(readRaw), end(readRaw) - (buffer[3].BufferType == SECBUFFER_EXTRA ? buffer[3].cbBuffer : 0));
 			} else if (sslReadStatus == SEC_I_CONTEXT_EXPIRED) {
 				assert(buffer[0].BufferType == SECBUFFER_DATA && buffer[0].cbBuffer == size_as<unsigned long>(readRaw));

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <ranges>
 #include <regex>
 #include <string>
 #include <string_view>
@@ -56,9 +57,9 @@ public:
 				Assert::AreEqual(line[0] == ch, std::regex_search(input, sm, stl), message.c_str());
 				if (line[0] == ch) {
 					auto match = line + '\t';
-					for (int i = 1; i < static_cast<int>(bm.size()); i++)
-						if (bm[i].matched)
-							match += " [" + bm[i].str() + "]";
+					for (auto const& m : bm | std::ranges::views::drop(1))
+						if (m.matched)
+							match += " [" + m.str() + "]";
 						else
 							match += " ()";
 					Logger::WriteMessage((match + '\n').c_str());

--- a/toolmenu.cpp
+++ b/toolmenu.cpp
@@ -803,7 +803,7 @@ void ShowPopupMenu(int Win, int Pos) {
 		EnableMenuItem(submenu, MENU_RENAME, selecting && connecting ? 0 : MF_GRAYED);
 #if defined(HAVE_TANDEM)
 		/* HP NonStop Server では CHMOD の仕様が異なるため使用不可 */
-		if (AskRealHostType() == HTYPE_TANDEM)
+		if (GetConnectingHost().HostType == HTYPE_TANDEM)
 			RemoveMenu(submenu, MENU_CHMOD, MF_BYCOMMAND);
 		else
 #endif
@@ -812,7 +812,7 @@ void ShowPopupMenu(int Win, int Pos) {
 		EnableMenuItem(submenu, MENU_URL_COPY, selecting && connecting ? 0 : MF_GRAYED);
 #if defined(HAVE_TANDEM)
 		/* OSS モードのときに表示されるように AskRealHostType() を使用する */
-		if (AskRealHostType() == HTYPE_TANDEM)
+		if (GetConnectingHost().HostType == HTYPE_TANDEM)
 			EnableMenuItem(submenu, MENU_SWITCH_OSS, connecting ? 0 : MF_GRAYED);
 		else
 #endif


### PR DESCRIPTION
雑多な改善を行う

- セキュアCRTへ置き換えることで `_CRT_SECURE_NO_WARNINGS` マクロを削除する
- コード分析で抑止していた警告に対応し、警告を有効化する
- 独自関数をSTLに置き換える
- 使われていない関数を削除する
- 消し忘れのプロトタイプ宣言を削除する
