### PR TITLE
fix #364, fix windows 10 sdk version.

### DIFF
--- a/ffftp.vcxproj
+++ b/ffftp.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{5D9496DB-45AF-4389-8FEE-27C9A2FA207A}</ProjectGuid>
     <RootNamespace>ffftp</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">


### PR DESCRIPTION
Windows 10 SDKのバージョンを固定し、バグありバージョンを回避する。