### PR TITLE
GDI Scaling

### DIFF
--- a/Resource/ffftp.exe.manifest
+++ b/Resource/ffftp.exe.manifest
@@ -18,7 +18,7 @@
 	</compatibility>
 	<application xmlns="urn:schemas-microsoft-com:asm.v3">
 		<windowsSettings>
-			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+			<gdiScaling xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">true</gdiScaling>
 		</windowsSettings>
 	</application>
 </assembly>

--- a/common.h
+++ b/common.h
@@ -159,7 +159,7 @@ constexpr FileType AllFileTyes[]{ FileType::All, FileType::Executable, FileType:
 #define YES_ALL			3
 #define YES_LIST		4
 
-#define VER_NUM					2000		/* 設定バージョン */
+#define VER_NUM					5600		/* 設定バージョン */
 
 /*===== ユーザ定義コマンド =====*/
 

--- a/common.h
+++ b/common.h
@@ -1176,8 +1176,6 @@ fs::path MakeDistinguishableFileName(fs::path&& path);
 #if defined(HAVE_TANDEM)
 void CalcExtentSize(TRANSPACKET *Pkt, LONGLONG Size);
 #endif
-int CalcPixelX(int x);
-int CalcPixelY(int y);
 
 /*===== opie.c =====*/
 

--- a/main.cpp
+++ b/main.cpp
@@ -117,7 +117,7 @@ static DWORD dwCookie;
 // マルチコアCPUの特定環境下でファイル通信中にクラッシュするバグ対策
 static DWORD MainThreadId;
 HANDLE ChangeNotification = INVALID_HANDLE_VALUE;
-static int ToolWinHeight;
+static int ToolWinHeight = 28;
 static HWND hHelpWin = NULL;
 static int NoopEnable = NO;
 
@@ -286,16 +286,7 @@ static int InitApp(int cmdShow)
 	{
 		Accel = LoadAcceleratorsW(GetFtpInst(), MAKEINTRESOURCEW(ffftp_accel));
 
-		// 高DPI対応
-		WinWidth = CalcPixelX(WinWidth);
-		WinHeight = CalcPixelY(WinHeight);
-		LocalWidth = CalcPixelX(LocalWidth);
-		TaskHeight = CalcPixelY(TaskHeight);
-		for (auto& width : LocalTabWidthDefault)
-			width = CalcPixelX(width);
 		std::copy(std::begin(LocalTabWidthDefault), std::end(LocalTabWidthDefault), std::begin(LocalTabWidth));
-		for (auto& width : RemoteTabWidthDefault)
-			width = CalcPixelX(width);
 		std::copy(std::begin(RemoteTabWidthDefault), std::end(RemoteTabWidthDefault), std::begin(RemoteTabWidth));
 
 		std::vector<std::wstring_view> args{ __wargv + 1, __wargv + __argc };
@@ -477,8 +468,6 @@ static int InitApp(int cmdShow)
 static bool MakeAllWindows(int cmdShow) {
 	WNDCLASSEXW classEx{ sizeof(WNDCLASSEXW), 0, FtpWndProc, 0, 0, GetFtpInst(), LoadIconW(GetFtpInst(), MAKEINTRESOURCEW(ffftp)), 0, GetSysColorBrush(COLOR_3DFACE), MAKEINTRESOURCEW(main_menu), FtpClass };
 	RegisterClassExW(&classEx);
-
-	ToolWinHeight = CalcPixelY(16) + 12;
 
 	if (SaveWinPos == NO) {
 		WinPosX = CW_USEDEFAULT;

--- a/misc.cpp
+++ b/misc.cpp
@@ -192,26 +192,3 @@ void CalcExtentSize(TRANSPACKET *Pkt, LONGLONG Size)
 	}
 }
 #endif
-
-static auto QueryDisplayDPI() {
-	static auto dpi = [] {
-		int x = 0, y = 0;
-		if (auto dc = GetDC(0)) {
-			x = GetDeviceCaps(dc, LOGPIXELSX);
-			y = GetDeviceCaps(dc, LOGPIXELSY);
-			ReleaseDC(0, dc);
-		}
-		return std::tuple<int, int>{ x, y };
-	}();
-	return dpi;
-}
-
-int CalcPixelX(int x) {
-	auto [dpix, _] = QueryDisplayDPI();
-	return (x * dpix + 96 / 2) / 96;
-}
-
-int CalcPixelY(int y) {
-	auto [_, dpiy] = QueryDisplayDPI();
-	return (y * dpiy + 96 / 2) / 96;
-}

--- a/statuswin.cpp
+++ b/statuswin.cpp
@@ -37,10 +37,7 @@ int MakeStatusBarWindow() {
 	hWndSbar = CreateWindowExW(0, STATUSCLASSNAMEW, nullptr, WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | SBARS_SIZEGRIP, 0, 0, 0, 0, GetMainHwnd(), 0, GetFtpInst(), nullptr);
 	if (!hWndSbar)
 		return FFFTP_FAIL;
-	static int parts[]{ 120, 190, 340, 500, 660, -1 };
-	for (auto& part : parts)
-		if (part != -1)
-			part = CalcPixelX(part);
+	int parts[] = { 120, 190, 340, 500, 660, -1 };
 	SendMessageW(hWndSbar, SB_SETPARTS, size_as<WPARAM>(parts), (LPARAM)parts);
 	return FFFTP_SUCCESS;
 }

--- a/toolmenu.cpp
+++ b/toolmenu.cpp
@@ -117,8 +117,8 @@ static HBITMAP GetImage(int iamgeId) {
 			if (auto src = CreateCompatibleDC(dc)) {
 				if (auto dest = CreateCompatibleDC(dc)) {
 					if (BITMAP bitmap; GetObjectW(original, sizeof(BITMAP), &bitmap) > 0) {
-						auto width = bitmap.bmWidth / 64 * CalcPixelX(16);
-						auto height = bitmap.bmHeight / 64 * CalcPixelY(16);
+						auto width = bitmap.bmWidth / 64 * 16;
+						auto height = bitmap.bmHeight / 64 * 16;
 						if (resized = CreateCompatibleBitmap(dc, width, height)) {
 							auto hSrcOld = SelectObject(src, original);
 							auto hDstOld = SelectObject(dest, resized);
@@ -180,7 +180,7 @@ static auto CreateToolbar(DWORD ws, UINT id, int bitmaps, HBITMAP image, const T
 	if (toolbar) {
 		TBADDBITMAP addbitmap{ 0, (UINT_PTR)image };
 		SendMessageW(toolbar, TB_ADDBITMAP, bitmaps, (LPARAM)&addbitmap);
-		SendMessageW(toolbar, TB_SETBITMAPSIZE, 0, MAKELPARAM(CalcPixelX(16), CalcPixelY(16)));
+		SendMessageW(toolbar, TB_SETBITMAPSIZE, 0, MAKELPARAM(16, 16));
 		SendMessageW(toolbar, TB_BUTTONSTRUCTSIZE, sizeof(TBBUTTON), 0);
 		SendMessageW(toolbar, TB_ADDBUTTONSW, size, (LPARAM)buttons);
 		SetWindowSubclass(toolbar, IgnoreRightClick, 0, 0);
@@ -194,7 +194,7 @@ static std::tuple<HWND, HWND> CreateComboBox(HWND toolbar, DWORD style, int widt
 	style |= WS_CHILD | WS_VISIBLE | WS_BORDER | WS_VSCROLL | CBS_DROPDOWN | CBS_AUTOHSCROLL;
 	RECT rect;
 	SendMessageW(toolbar, TB_GETITEMRECT, 3, (LPARAM)&rect);
-	auto combobox = CreateWindowExW(WS_EX_CLIENTEDGE, WC_COMBOBOXW, nullptr, style, rect.right, rect.top, width - rect.right, CalcPixelY(200), toolbar, (HMENU)IntToPtr(menuId), GetFtpInst(), nullptr);
+	auto combobox = CreateWindowExW(WS_EX_CLIENTEDGE, WC_COMBOBOXW, nullptr, style, rect.right, rect.top, width - rect.right, 200, toolbar, (HMENU)IntToPtr(menuId), GetFtpInst(), nullptr);
 	HWND edit = 0;
 	if (combobox) {
 		if (COMBOBOXINFO ci{ sizeof(COMBOBOXINFO) }; SendMessageW(combobox, CB_GETCOMBOBOXINFO, 0, (LPARAM)&ci)) {
@@ -228,7 +228,7 @@ bool MakeToolBarWindow() {
 	if (hWndTbarLocal = CreateToolbar(BTNS_GROUP, 2, 2, remoteImage, localButtons, size_as<int>(localButtons), 0, AskToolWinHeight(), LocalWidth, AskToolWinHeight()); !hWndTbarLocal)
 		return false;
 	SendMessageW(hWndTbarLocal, TB_GETITEMRECT, 3, (LPARAM)&rect);
-	auto font = CreateFontW(rect.bottom - rect.top - CalcPixelY(8), 0, 0, 0, 0, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, DEFAULT_QUALITY, DEFAULT_PITCH, L"MS Shell Dlg");
+	auto font = CreateFontW(rect.bottom - rect.top - 8, 0, 0, 0, 0, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, DEFAULT_QUALITY, DEFAULT_PITCH, L"MS Shell Dlg");
 	std::tie(hWndDirLocal, hWndDirLocalEdit) = CreateComboBox(hWndTbarLocal, CBS_SORT, LocalWidth, COMBO_LOCAL, true, font);
 	if (hWndDirLocal == NULL)
 		return false;


### PR DESCRIPTION
High DPI対応は不完全でところどころフォントサイズ調整やサイズ計算が行き届いていなかった。新たにGDI Scalingという機能が登場しているので、High DPI対応を無効化した上で、GDI Scalingに切り替える。