### PR TITLE
use vformat.

### DIFF
--- a/common.h
+++ b/common.h
@@ -1045,7 +1045,7 @@ namespace detail {
 }
 template<class... Args>
 static inline std::tuple<int, std::wstring> Command(std::shared_ptr<SocketContext> socket, int* CancelCheckWork, std::wstring_view format, const Args&... args) {
-	return !socket ? std::tuple{ 429, L""s } : detail::command(socket, CancelCheckWork, std::format(format, args...));
+	return !socket ? std::tuple{ 429, L""s } : detail::command(socket, CancelCheckWork, std::vformat(format, std::make_wformat_args(args...)));
 }
 
 /*===== getput.c =====*/

--- a/connect.cpp
+++ b/connect.cpp
@@ -941,7 +941,7 @@ static std::shared_ptr<SocketContext> DoConnectCrypt(int CryptMode, HOSTDATA* Ho
 									Pass = UserMailAdrs;
 								}
 
-								auto const user = Fwall != FWALL_FU_FP_USER && Fwall != FWALL_USER ? User : std::format(Port == IPPORT_FTP ? L"{}{}{}"sv : L"{}{}{} {}"sv, User, (wchar_t)FwallDelimiter, Host, Port);
+								auto const user = Fwall != FWALL_FU_FP_USER && Fwall != FWALL_USER ? User : std::vformat(Port == IPPORT_FTP ? L"{}{}{}"sv : L"{}{}{} {}"sv, std::make_wformat_args(User, (wchar_t)FwallDelimiter, Host, Port));
 
 								// FTPES対応
 								if (CryptMode == CRYPT_FTPES) {

--- a/filelist.cpp
+++ b/filelist.cpp
@@ -767,7 +767,7 @@ static auto FileTimeToString(FILETIME ft, int InfoExist) {
 			else
 				str += L"           "sv;
 			if (InfoExist & FINFO_TIME)
-				std::format_to(std::back_inserter(str), DispTimeSeconds == YES ? L"{:02d}:{:02d}:{:02d}"sv : L"{:02d}:{:02d}"sv, st.wHour, st.wMinute, st.wSecond);
+				std::vformat_to(std::back_inserter(str), DispTimeSeconds == YES ? L"{:02d}:{:02d}:{:02d}"sv : L"{:02d}:{:02d}"sv, std::make_wformat_args(st.wHour, st.wMinute, st.wSecond));
 			else
 				str += DispTimeSeconds == YES ? L"        "sv : L"     "sv;
 		}

--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -2130,7 +2130,7 @@ void CopyURLtoClipBoard() {
 	if (empty(FileListBase))
 		return;
 	auto const curHost = GetCurHost();
-	auto baseAddress = std::format(curHost.Port != IPPORT_FTP ? L"ftp://{0}:{1}"sv : L"ftp://{0}"sv, curHost.HostAdrs, curHost.Port);
+	auto baseAddress = std::vformat(curHost.Port != IPPORT_FTP ? L"ftp://{0}:{1}"sv : L"ftp://{0}"sv, std::make_wformat_args(curHost.HostAdrs, curHost.Port));
 	{
 		auto dir = SetSlashTail(std::wstring{ AskRemoteCurDir() });
 		if (AskHostType() == HTYPE_VMS) {

--- a/getput.cpp
+++ b/getput.cpp
@@ -817,7 +817,7 @@ static int SendUploadCommand(TRANSPACKET* Pkt, int& Resume, int* CancelCheckWork
 		Pkt->ExistSize = 0;
 #if defined(HAVE_TANDEM)
 		if (AskHostType() == HTYPE_TANDEM && AskOSS() == NO && Pkt->Type != TYPE_A)
-			extra = std::format(Pkt->PriExt == DEF_PRIEXT && Pkt->SecExt == DEF_SECEXT && Pkt->MaxExt == DEF_MAXEXT ? L",{}"sv : L",{},{},{},{}"sv, Pkt->FileCode, Pkt->PriExt, Pkt->SecExt, Pkt->MaxExt);
+			extra = std::vformat(Pkt->PriExt == DEF_PRIEXT && Pkt->SecExt == DEF_SECEXT && Pkt->MaxExt == DEF_MAXEXT ? L",{}"sv : L",{},{},{},{}"sv, std::make_wformat_args(Pkt->FileCode, Pkt->PriExt, Pkt->SecExt, Pkt->MaxExt));
 #endif
 	}
 	auto [code, text] = Command(Pkt->ctrl_skt, CancelCheckWork, L"{}{}{}"sv, cmd, Pkt->Remote, extra);

--- a/main.cpp
+++ b/main.cpp
@@ -169,7 +169,7 @@ static auto version() {
 	auto const ms = static_cast<VS_FIXEDFILEINFO*>(block)->dwProductVersionMS, ls = static_cast<VS_FIXEDFILEINFO*>(block)->dwProductVersionLS;
 	auto const major = HIWORD(ms), minor = LOWORD(ms), patch = HIWORD(ls), build = LOWORD(ls);
 	auto const format = build != 0 ? L"{}.{}.{}.{}"sv : patch != 0 ? L"{}.{}.{}"sv : L"{}.{}"sv;
-	return std::format(format, major, minor, patch, build);
+	return std::vformat(format, std::make_wformat_args(major, minor, patch, build));
 }
 
 
@@ -508,7 +508,7 @@ static bool MakeAllWindows(int cmdShow) {
 
 // ウインドウのタイトルを表示する
 void DispWindowTitle() {
-	auto const text = std::format(AskConnecting() == YES ? L"{0} ({1}) - FFFTP"sv : L"FFFTP ({1})"sv, TitleHostName, FilterStr);
+	auto const text = std::vformat(AskConnecting() == YES ? L"{0} ({1}) - FFFTP"sv : L"FFFTP ({1})"sv, std::make_wformat_args(TitleHostName, FilterStr));
 	SetWindowTextW(GetMainHwnd(), text.c_str());
 }
 
@@ -1915,7 +1915,7 @@ void ExecViewer2(fs::path const& path1, fs::path const& path2, int App) {
 	/* そこで、関連付けられたプログラムの起動はShellExecute()を使う。	*/
 	auto format = path1.native().find(L' ') == std::wstring::npos && path2.native().find(L' ') == std::wstring::npos ? LR"({} {} {})"sv : LR"({} "{}" "{}")"sv;
 	auto const executable = std::wstring_view{ ViewerName[App] }.substr(2);		/* 先頭の "d " は読み飛ばす */
-	auto commandLine = std::format(format, executable, path1.native(), path2.native());
+	auto commandLine = std::vformat(format, std::make_wformat_args(executable, path1.native(), path2.native()));
 	Debug(L"FindExecutable - {}"sv, commandLine);
 	STARTUPINFOW si{ sizeof(STARTUPINFOW), nullptr, nullptr, nullptr, 0, 0, 0, 0, 0, 0, 0, 0, SW_SHOWNORMAL };
 	if (ProcessInformation pi; __pragma(warning(suppress:6335)) !CreateProcessW(nullptr, data(commandLine), nullptr, nullptr, false, 0, nullptr, systemDirectory().c_str(), &si, &pi)) {

--- a/remote.cpp
+++ b/remote.cpp
@@ -275,7 +275,7 @@ int DoDirList(std::wstring_view AddOpt, int Num, int* CancelCheckWork) {
 	if (auto const connectingHost = GetConnectingHost(); connectingHost.ListCmdOnly == NO) {
 		MainTransPkt.Command = L"NLST"s;
 		if (!empty(connectingHost.LsName))
-			MainTransPkt.Command += std::format(AskHostType() == HTYPE_ACOS || AskHostType() == HTYPE_ACOS_4? L" '{}'"sv : L" {}"sv, connectingHost.LsName);
+			MainTransPkt.Command += std::vformat(AskHostType() == HTYPE_ACOS || AskHostType() == HTYPE_ACOS_4? L" '{}'"sv : L" {}"sv, std::make_wformat_args(connectingHost.LsName));
 		if (!empty(AddOpt))
 			MainTransPkt.Command += AddOpt;
 	} else {


### PR DESCRIPTION
VS2022 17.2からstd::formatのfmt引数は定数式とする必要があり、そうではない場合はvformatを使う必要がある。そのため、定数式でない個所は事前にvformatに移行しておく。