### PR TITLE
fix #369

### DIFF
--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -643,12 +643,8 @@ static int CheckLocalFile(TRANSPACKET *Pkt) noexcept {
 // リモート側のパスから必要なディレクトリを作成
 int MakeDirFromRemotePath(fs::path const& RemoteFile, fs::path const& Old, int FirstAdd) {
 	fs::path path;
-
-	fs::path RemotePath = RemoteFile;
-	RemotePath.remove_filename();
-	fs::path OldPath = Old;
-	OldPath.remove_filename();
-
+	auto const RemotePath = RemoteFile.parent_path();
+	auto const OldPath = Old.parent_path();
 	auto rit = RemotePath.begin(), rend = RemotePath.end();
 	for (auto oit = OldPath.begin(), oend = OldPath.end(); rit != rend && oit != oend && *rit == *oit; ++rit, ++oit)
 		path /= *rit;

--- a/ftpproc.cpp
+++ b/ftpproc.cpp
@@ -643,8 +643,14 @@ static int CheckLocalFile(TRANSPACKET *Pkt) noexcept {
 // リモート側のパスから必要なディレクトリを作成
 int MakeDirFromRemotePath(fs::path const& RemoteFile, fs::path const& Old, int FirstAdd) {
 	fs::path path;
-	auto rit = RemoteFile.begin(), rend = RemoteFile.end();
-	for (auto oit = Old.begin(), oend = Old.end(); rit != rend && oit != oend && *rit == *oit; ++rit, ++oit)
+
+	fs::path RemotePath = RemoteFile;
+	RemotePath.remove_filename();
+	fs::path OldPath = Old;
+	OldPath.remove_filename();
+
+	auto rit = RemotePath.begin(), rend = RemotePath.end();
+	for (auto oit = OldPath.begin(), oend = OldPath.end(); rit != rend && oit != oend && *rit == *oit; ++rit, ++oit)
 		path /= *rit;
 	if (rit == rend)
 		return NO;


### PR DESCRIPTION
引数のRemoteFile、Oldの最後尾要素にはファイル名が含まれているため、
指定したファイル名のディレクトリが作成されていました。
remove_filename()でファイル名を取り除き、ディレクトリが作成されないように修正しました。
