### PR TITLE
GitHub Actionsで出ているエラーの修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         MSBuild.exe ffftp.sln /p:Platform=$('${{matrix.platform}}' -replace 'x86', 'Win32') /p:Configuration=${{matrix.configuration}}
     - name: Upload artifacts (ffftp)
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         name: ${{matrix.platform}}-${{matrix.configuration}}-ffftp
         path: ${{matrix.configuration}}/${{matrix.platform}}

--- a/common.h
+++ b/common.h
@@ -1292,7 +1292,7 @@ static inline auto replace(std::basic_string_view<Char> input, boost::basic_rege
 }
 template<int captionId = IDS_APP>
 static inline auto Message(HWND owner, int textId, DWORD style) noexcept {
-	MSGBOXPARAMSW msgBoxParams{ sizeof MSGBOXPARAMSW, owner, GetFtpInst(), MAKEINTRESOURCEW(textId), MAKEINTRESOURCEW(captionId), style, nullptr, 0, nullptr, LANG_NEUTRAL };
+	MSGBOXPARAMSW msgBoxParams{ sizeof(MSGBOXPARAMSW), owner, GetFtpInst(), MAKEINTRESOURCEW(textId), MAKEINTRESOURCEW(captionId), style, nullptr, 0, nullptr, LANG_NEUTRAL };
 	return MessageBoxIndirectW(&msgBoxParams);
 }
 template<int captionId = IDS_APP>


### PR DESCRIPTION
フォークしたリポジトリでGitHub Actionsを有効にしてみたところ、下記のエラーが出ていました。

```
Error: Missing download info for actions/upload-artifact@v2.2.4
```

調べたところ、以下のような記載がありましたのでv4にアップデートしました。 8f8c672ef15e4c5c16c85c89e6be0cab19e8a43e 

https://github.com/actions/upload-artifact

> actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. Please update your workflow to use v4 of the artifact actions. This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.


---

また、上記の修正後、更に下記のビルドエラーが出ていたのでこちらも修正しました。 b50a51710fb4faa1cec771430fe9d7e4d0049f7a

```
"D:\a\ffftp\ffftp\ffftp.sln" (default target) (1) ->
"D:\a\ffftp\ffftp\ffftp.vcxproj" (default target) (2) ->
(ClCompile target) -> 
  D:\a\ffftp\ffftp\common.h(1295,37): error C2760: syntax error: 'MSGBOXPARAMSW' was unexpected here; expected '(' [D:\a\ffftp\ffftp\ffftp.vcxproj]
  D:\a\ffftp\ffftp\common.h(1295,50): error C3878: syntax error: unexpected token ',' following 'simple-declaration' [D:\a\ffftp\ffftp\ffftp.vcxproj]
  D:\a\ffftp\ffftp\common.h(1295,169): error C2760: syntax error: '}' was unexpected here; expected ';' [D:\a\ffftp\ffftp\ffftp.vcxproj]

```